### PR TITLE
BUG/ENH: Fix/refactor logging, fixes #258

### DIFF
--- a/src/vak/cli/eval.py
+++ b/src/vak/cli/eval.py
@@ -1,9 +1,14 @@
-from datetime import datetime
+import logging
 from pathlib import Path
 
-from .. import config
-from .. import core
-from .. import logging
+from .. import (
+    config,
+    core,
+)
+from ..logging import config_logging_for_cli
+
+
+logger = logging.getLogger(__name__)
 
 
 def eval(toml_path):
@@ -27,14 +32,14 @@ def eval(toml_path):
             f"eval called with a config.toml file that does not have a EVAL section: {toml_path}"
         )
 
-    # ---- set up logging ----------------------------------------------------------------------------------------------
-    timenow = datetime.now().strftime("%y%m%d_%H%M%S")
-    logger = logging.get_logger(
+    # ---- set up logging ---------------------------------------------------------------------------------------------
+    config_logging_for_cli(
         log_dst=cfg.eval.output_dir,
-        caller="eval",
-        timestamp=timenow,
-        logger_name=__name__,
+        log_stem="eval",
+        level="INFO",
+        force=True
     )
+
     logger.info("Logging results to {}".format(cfg.eval.output_dir))
 
     model_config_map = config.models.map_from_path(toml_path, cfg.eval.models)
@@ -51,5 +56,4 @@ def eval(toml_path):
         spect_key=cfg.spect_params.spect_key,
         timebins_key=cfg.spect_params.timebins_key,
         device=cfg.eval.device,
-        logger=logger,
     )

--- a/src/vak/cli/learncurve.py
+++ b/src/vak/cli/learncurve.py
@@ -1,11 +1,16 @@
+import logging
 from pathlib import Path
 import shutil
 
-from .. import config
-from .. import core
-from .. import logging
+from .. import (
+    config,
+    core
+)
+from ..logging import config_logging_for_cli
 from ..paths import generate_results_dir_name_as_path
-from ..timenow import get_timenow_as_str
+
+
+logger = logging.getLogger(__name__)
 
 
 def learning_curve(toml_path):
@@ -13,17 +18,13 @@ def learning_curve(toml_path):
     range of sizes and then measure accuracy of those models on a test set.
     Function called by command-line interface.
 
+    Trains models, saves results in new directory within root_results_dir specified
+    in config.toml file, and adds path to that new directory to config.toml file.
+
     Parameters
     ----------
     toml_path : str, Path
         path to a configuration file in TOML format.
-
-    Returns
-    -------
-    None
-
-    Trains models, saves results in new directory within root_results_dir specified
-    in config.toml file, and adds path to that new directory to config.toml file.
     """
     toml_path = Path(toml_path)
     cfg = config.parse.from_toml_path(toml_path)
@@ -40,11 +41,11 @@ def learning_curve(toml_path):
     shutil.copy(toml_path, results_path)
 
     # ---- set up logging ----------------------------------------------------------------------------------------------
-    logger = logging.get_logger(
+    config_logging_for_cli(
         log_dst=results_path,
-        caller="learncurve",
-        timestamp=get_timenow_as_str(),
-        logger_name=__name__,
+        log_stem="learncurve",
+        level="INFO",
+        force=True
     )
     logger.info("Logging results to {}".format(results_path))
 
@@ -70,5 +71,4 @@ def learning_curve(toml_path):
         ckpt_step=cfg.learncurve.ckpt_step,
         patience=cfg.learncurve.patience,
         device=cfg.learncurve.device,
-        logger=logger,
     )

--- a/src/vak/cli/predict.py
+++ b/src/vak/cli/predict.py
@@ -1,9 +1,14 @@
-from datetime import datetime
+import logging
 from pathlib import Path
 
-from .. import config
-from .. import core
-from .. import logging
+from .. import (
+    config,
+    core
+)
+from ..logging import config_logging_for_cli
+
+
+logger = logging.getLogger(__name__)
 
 
 def predict(toml_path):
@@ -14,10 +19,6 @@ def predict(toml_path):
     ----------
     toml_path : str, Path
         path to a configuration file in TOML format.
-
-    Returns
-    -------
-    None
     """
     toml_path = Path(toml_path)
     cfg = config.parse.from_toml_path(toml_path)
@@ -28,12 +29,11 @@ def predict(toml_path):
         )
 
     # ---- set up logging ----------------------------------------------------------------------------------------------
-    timenow = datetime.now().strftime("%y%m%d_%H%M%S")
-    logger = logging.get_logger(
+    config_logging_for_cli(
         log_dst=cfg.predict.output_dir,
-        caller="predict",
-        timestamp=timenow,
-        logger_name=__name__,
+        log_stem="predict",
+        level="INFO",
+        force=True
     )
     logger.info("Logging results to {}".format(cfg.prep.output_dir))
 
@@ -55,5 +55,4 @@ def predict(toml_path):
         min_segment_dur=cfg.predict.min_segment_dur,
         majority_vote=cfg.predict.majority_vote,
         save_net_outputs=cfg.predict.save_net_outputs,
-        logger=logger,
     )

--- a/src/vak/cli/prep.py
+++ b/src/vak/cli/prep.py
@@ -1,14 +1,19 @@
 from pathlib import Path
-from datetime import datetime
+import logging
 import warnings
 
 import toml
 
-from .. import config
-from .. import core
-from .. import logging
+from .. import (
+    config,
+    core
+)
 from ..config.parse import _load_toml_from_path
 from ..config.validators import are_sections_valid
+from ..logging import config_logging_for_cli
+
+
+logger = logging.getLogger(__name__)
 
 
 def purpose_from_toml(config_toml, toml_path=None):
@@ -39,7 +44,7 @@ SECTIONS_PREP_SHOULD_PARSE = ("PREP", "SPECT_PARAMS")
 
 
 def prep(toml_path):
-    """prepare datasets from vocalizations.
+    """Prepare datasets from vocalizations.
     Function called by command-line interface.
 
     Parameters
@@ -47,10 +52,6 @@ def prep(toml_path):
     toml_path : str, Path
         path to a configuration file in TOML format.
         Used to rewrite file with options determined by this function and needed for other functions
-
-    Returns
-    -------
-    None
 
     Notes
     -----
@@ -115,18 +116,17 @@ def prep(toml_path):
             cfg.prep.labelset = None
 
     # ---- set up logging ----------------------------------------------------------------------------------------------
-    timenow = datetime.now().strftime("%y%m%d_%H%M%S")
-    logger = logging.get_logger(
+    config_logging_for_cli(
         log_dst=cfg.prep.output_dir,
-        caller="prep",
-        timestamp=timenow,
-        logger_name=__name__,
+        log_stem="prep",
+        level="INFO",
+        force=True
     )
 
     section = purpose.upper()
     logger.info(
-        f"determined that purpose of config file is: {purpose}\n"
-        f"will add 'csv_path' option to '{section}' section"
+        f"Determined that purpose of config file is: {purpose}.\n"
+        f"Will add 'csv_path' option to '{section}' section."
     )
 
     vak_df, csv_path = core.prep(
@@ -143,7 +143,6 @@ def prep(toml_path):
         train_dur=cfg.prep.train_dur,
         val_dur=cfg.prep.val_dur,
         test_dur=cfg.prep.test_dur,
-        logger=logger,
     )
 
     # use config and section from above to add csv_path to config.toml file

--- a/src/vak/cli/train.py
+++ b/src/vak/cli/train.py
@@ -1,28 +1,29 @@
+import logging
 from pathlib import Path
 import shutil
 
-from .. import config
-from .. import core
-from .. import logging
+from .. import (
+    config,
+    core
+)
+from ..logging import config_logging_for_cli
 from ..paths import generate_results_dir_name_as_path
-from ..timenow import get_timenow_as_str
+
+
+logger = logging.getLogger(__name__)
 
 
 def train(toml_path):
     """train models using training set specified in config.toml file.
     Function called by command-line interface.
 
+    Trains models, saves results in new directory within root_results_dir specified
+    in config.toml file, and adds path to that new directory to config.toml file.
+
     Parameters
     ----------
     toml_path : str, Path
         path to a configuration file in TOML format.
-
-    Returns
-    -------
-    None
-
-    Trains models, saves results in new directory within root_results_dir specified
-    in config.toml file, and adds path to that new directory to config.toml file.
     """
     toml_path = Path(toml_path)
     cfg = config.parse.from_toml_path(toml_path)
@@ -39,11 +40,11 @@ def train(toml_path):
     shutil.copy(toml_path, results_path)
 
     # ---- set up logging ----------------------------------------------------------------------------------------------
-    logger = logging.get_logger(
+    config_logging_for_cli(
         log_dst=results_path,
-        caller="train",
-        timestamp=get_timenow_as_str(),
-        logger_name=__name__,
+        log_stem="train",
+        level="INFO",
+        force=True
     )
     logger.info("Logging results to {}".format(results_path))
 
@@ -69,5 +70,4 @@ def train(toml_path):
         ckpt_step=cfg.train.ckpt_step,
         patience=cfg.train.patience,
         device=cfg.train.device,
-        logger=logger,
     )

--- a/src/vak/core/learncurve/train_dur_csv_paths.py
+++ b/src/vak/core/learncurve/train_dur_csv_paths.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+import logging
 import pprint
 import re
 import shutil
@@ -9,7 +10,9 @@ import pandas as pd
 from ... import split
 from ...converters import expanded_user_path
 from ...datasets.window_dataset import WindowDataset
-from ...logging import log_or_print
+
+
+logger = logging.getLogger(__name__)
 
 
 # pattern used by path.glob to find all training data subset csvs within previous_run_path
@@ -84,7 +87,6 @@ def from_dir(
     spect_key,
     timebins_key,
     labelmap,
-    logger=None,
 ):
     """return a ``dict`` mapping training dataset durations to dataset csv paths
     from a previous run of `vak.core.learncurve.learning_curve`.
@@ -126,11 +128,6 @@ def from_dir(
     labelmap : dict
         that maps labelset to consecutive integers
 
-    Other Parameters
-    ----------------
-    logger : logging.Logger
-        instance created by ``vak.logging.get_logger``. Default is None.
-
     Returns
     -------
     train_dur_csv_paths : dict
@@ -171,11 +168,9 @@ def from_dir(
             f"Found the following:\n{pprint.pformat(train_dur_csv_paths, indent=4)}"
         )
 
-    log_or_print(
+    logger.info(
         f"Using the following training subsets from previous run path:\n"
         f"{pprint.pformat(train_dur_csv_paths, indent=4)}",
-        logger=logger,
-        level="info",
     )
 
     # need to copy .csv files, and change path in train_dur_csv_paths to point to copies
@@ -263,7 +258,6 @@ def from_df(
     spect_key,
     timebins_key,
     labelmap,
-    logger=None,
 ):
     """return a ``dict`` mapping training dataset durations to dataset csv paths.
 
@@ -320,10 +314,8 @@ def from_df(
     """
     train_dur_csv_paths = defaultdict(list)
     for train_dur in train_set_durs:
-        log_or_print(
-            f"subsetting training set for training set of duration: {train_dur}",
-            logger=logger,
-            level="info",
+        logger.info(
+            f"Subsetting training set for training set of duration: {train_dur}",
         )
         results_path_this_train_dur = results_path.joinpath(
             train_dur_dirname(train_dur)

--- a/src/vak/files/spect.py
+++ b/src/vak/files/spect.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 import numpy as np
@@ -5,9 +6,11 @@ from dask import bag as db
 from dask.diagnostics import ProgressBar
 
 from .. import constants
-from ..logging import log_or_print
 from .files import find_fname
 from ..timebins import timebin_dur_from_vec
+
+
+logger = logging.getLogger(__name__)
 
 
 def find_audio_fname(spect_path, audio_ext=None):
@@ -120,7 +123,6 @@ def is_valid_set_of_spect_files(
     timebins_key="t",
     spect_key="s",
     n_decimals_trunc=5,
-    logger=None,
 ):
     """validate a set of spectrogram files that will be used as a dataset.
     Validates that:
@@ -190,7 +192,7 @@ def is_valid_set_of_spect_files(
 
     spect_paths_bag = db.from_sequence(spect_paths)
 
-    log_or_print("validating set of spectrogram files", logger=logger, level="info")
+    logger.info("validating set of spectrogram files")
 
     with ProgressBar():
         path_freqbins_timebin_dur_tups = list(spect_paths_bag.map(_validate))

--- a/src/vak/io/audio.py
+++ b/src/vak/io/audio.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 
@@ -5,13 +6,17 @@ import numpy as np
 import dask.bag as db
 from dask.diagnostics import ProgressBar
 
-from .. import constants
-from .. import files
+from .. import (
+    constants,
+    files
+)
 from ..annotation import source_annot_map
 from ..converters import labelset_to_set
 from ..config.spect_params import SpectParamsConfig
-from ..logging import log_or_print
 from ..spect import spectrogram
+
+
+logger = logging.getLogger(__name__)
 
 
 def files_from_dir(audio_dir, audio_format):
@@ -46,7 +51,6 @@ def to_spect(
     annot_list=None,
     audio_annot_map=None,
     labelset=None,
-    logger=None,
 ):
     """makes spectrograms from audio files and saves in array files
 
@@ -79,11 +83,6 @@ def to_spect(
         If not None, skip files where the associated annotations contain labels not in ``labelset``.
         ``labelset`` is converted to a Python ``set`` using ``vak.converters.labelset_to_set``.
         See help for that function for details on how to specify labelset.
-
-    Other Parameters
-    ----------------
-    logger : logging.Logger
-        instance created by vak.logging.get_logger. Default is None.
 
     Returns
     -------
@@ -179,7 +178,7 @@ def to_spect(
         if annot_list:
             audio_annot_map = source_annot_map(audio_files, annot_list)
 
-    log_or_print("creating array files with spectrograms", logger=logger, level="info")
+    logger.info("creating array files with spectrograms")
 
     # use mapping (if generated/supplied) with labelset, if supplied, to filter
     if audio_annot_map:
@@ -195,11 +194,9 @@ def to_spect(
                     # because there's some label in labels that's not in labelset
                     audio_annot_map.pop(audio_file)
                     extra_labels = annot_labelset - labelset
-                    log_or_print(
+                    logger.info(
                         f"Found labels, {extra_labels}, in {Path(audio_file).name}, "
                         "that are not in labels_mapping. Skipping file.",
-                        logger=logger,
-                        level="info",
                     )
         audio_files = sorted(list(audio_annot_map.keys()))
 

--- a/src/vak/io/dataframe.py
+++ b/src/vak/io/dataframe.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import logging
 
 import attrs
 import crowsetta
@@ -8,7 +9,9 @@ from . import audio, spect
 from .. import annotation
 from ..config.spect_params import SpectParamsConfig
 from ..converters import expanded_user_path, labelset_to_set
-from ..logging import log_or_print
+
+
+logger = logging.getLogger(__name__)
 
 
 def from_files(
@@ -20,7 +23,6 @@ def from_files(
     spect_format=None,
     spect_params=None,
     spect_output_dir=None,
-    logger=None,
 ):
     """create a pandas DataFrame representing a dataset for machine learning
     from a set of files in a directory
@@ -69,11 +71,6 @@ def from_files(
         Default is None, in which case it defaults to ``data_dir``.
         A new directory will be created in ``spect_output_dir`` with
         the name 'spectrograms_generated_{time stamp}'.
-
-    Other Parameters
-    ----------------
-    logger : logging.Logger
-        instance created by vak.logging.get_logger. Default is None.
 
     Returns
     -------
@@ -124,10 +121,8 @@ def from_files(
 
     # ------ if making dataset from audio files, need to make into array files first! ----------------------------------
     if audio_format:
-        log_or_print(
+        logger.info(
             f"making array files containing spectrograms from audio files in: {data_dir}",
-            logger=logger,
-            level="info",
         )
         audio_files = audio.files_from_dir(data_dir, audio_format)
 
@@ -157,17 +152,13 @@ def from_files(
 
     if spect_files:  # because we just made them, and put them in spect_output_dir
         to_dataframe_kwargs["spect_files"] = spect_files
-        log_or_print(
+        logger.info(
             f"creating dataset from spectrogram files in: {spect_output_dir}",
-            logger=logger,
-            level="info",
         )
     else:
         to_dataframe_kwargs["spect_dir"] = data_dir
-        log_or_print(
+        logger.info(
             f"creating dataset from spectrogram files in: {data_dir}",
-            logger=logger,
-            level="info",
         )
 
     if spect_params: # get relevant keys for accessing arrays from array files
@@ -176,7 +167,7 @@ def from_files(
         for key in ['freqbins_key', 'timebins_key', 'spect_key', 'audio_path_key']:
             to_dataframe_kwargs[key] = spect_params[key]
 
-    vak_df = spect.to_dataframe(**to_dataframe_kwargs, logger=logger)
+    vak_df = spect.to_dataframe(**to_dataframe_kwargs)
     return vak_df
 
 

--- a/src/vak/models/models.py
+++ b/src/vak/models/models.py
@@ -32,7 +32,7 @@ def find():
         yield entrypoint.name, entrypoint.load()
 
 
-def from_model_config_map(model_config_map, num_classes, input_shape, logger=None):
+def from_model_config_map(model_config_map, num_classes, input_shape):
     """get models that are ready to train, given their names and configurations.
 
     Given a dictionary that maps model names to configurations,
@@ -48,8 +48,6 @@ def from_model_config_map(model_config_map, num_classes, input_shape, logger=Non
     input_shape : tuple, list
         e.g. (channels, height, width).
         Batch size is not required for input shape.
-    logger : logging.Logger
-        instance created by vak.logging.get_logger. Default is None.
 
     Returns
     -------
@@ -69,7 +67,7 @@ def from_model_config_map(model_config_map, num_classes, input_shape, logger=Non
             model = MODELS[model_name].from_config(config=model_config)
         except KeyError:
             model = MODELS[f"{model_name}Model"].from_config(
-                config=model_config, logger=logger
+                config=model_config
             )
         models_map[model_name] = model
     return models_map

--- a/src/vak/models/teenytweetynet.py
+++ b/src/vak/models/teenytweetynet.py
@@ -119,7 +119,7 @@ class TeenyTweetyNet(nn.Module):
 
 class TeenyTweetyNetModel(Model):
     @classmethod
-    def from_config(cls, config, logger=None):
+    def from_config(cls, config):
         network = TeenyTweetyNet(**config["network"])
         loss = nn.CrossEntropyLoss(**config["loss"])
         optimizer = torch.optim.Adam(params=network.parameters(), **config["optimizer"])
@@ -134,5 +134,4 @@ class TeenyTweetyNetModel(Model):
             optimizer=optimizer,
             loss=loss,
             metrics=metrics,
-            logger=logger,
         )

--- a/src/vak/split/split.py
+++ b/src/vak/split/split.py
@@ -1,9 +1,13 @@
+import logging
+
 import numpy as np
 
 from .algorithms import brute_force
 from .algorithms.validate import validate_split_durations
 from ..labels import from_df as labels_from_df
-from ..logging import log_or_print
+
+
+logger = logging.getLogger(__name__)
 
 
 def train_test_dur_split_inds(
@@ -14,7 +18,6 @@ def train_test_dur_split_inds(
     test_dur,
     val_dur=None,
     algo="brute_force",
-    logger=None,
 ):
     """return indices to split a dataset into training, test, and validation sets of specified durations.
 
@@ -75,11 +78,9 @@ def train_test_dur_split_inds(
             f"training, test, and (if specified) validation sets: {total_target_dur}"
         )
 
-    log_or_print(
+    logger.info(
         f"Total target duration of splits: {total_target_dur} seconds. "
         f"Will be drawn from dataset with total duration: {total_dur:.3f}.",
-        logger=logger,
-        level="info",
     )
 
     if algo == "brute_force":
@@ -93,7 +94,7 @@ def train_test_dur_split_inds(
 
 
 def dataframe(
-    vak_df, labelset, train_dur=None, test_dur=None, val_dur=None, logger=None
+    vak_df, labelset, train_dur=None, test_dur=None, val_dur=None
 ):
     """split a dataset of vocalizations into training, test, and (optionally) validation subsets,
     specified by their duration.
@@ -145,7 +146,6 @@ def dataframe(
         train_dur=train_dur,
         test_dur=test_dur,
         val_dur=val_dur,
-        logger=logger,
     )
 
     # start off with all elements set to 'None'

--- a/tests/test_core/test_eval.py
+++ b/tests/test_core/test_eval.py
@@ -58,7 +58,6 @@ def test_eval(
         spect_key=cfg.spect_params.spect_key,
         timebins_key=cfg.spect_params.timebins_key,
         device=cfg.eval.device,
-        logger=None,
     )
 
     assert eval_output_matches_expected(model_config_map, output_dir)

--- a/tests/test_core/test_learncurve.py
+++ b/tests/test_core/test_learncurve.py
@@ -88,7 +88,6 @@ def test_learncurve(specific_config, tmp_path, model, device):
         ckpt_step=cfg.learncurve.ckpt_step,
         patience=cfg.learncurve.patience,
         device=cfg.learncurve.device,
-        logger=None,
     )
 
     assert learncurve_output_matches_expected(cfg, model_config_map, results_path)
@@ -139,7 +138,6 @@ def test_learncurve_no_results_path(specific_config, tmp_path, model, device):
         ckpt_step=cfg.learncurve.ckpt_step,
         patience=cfg.learncurve.patience,
         device=cfg.learncurve.device,
-        logger=None,
     )
 
     results_path = sorted(root_results_dir.glob(f"{vak.constants.RESULTS_DIR_PREFIX}*"))

--- a/tests/test_core/test_predict.py
+++ b/tests/test_core/test_predict.py
@@ -73,7 +73,6 @@ def test_predict(
         min_segment_dur=cfg.predict.min_segment_dur,
         majority_vote=cfg.predict.majority_vote,
         save_net_outputs=cfg.predict.save_net_outputs,
-        logger=None,
     )
 
     assert predict_output_matches_expected(output_dir, cfg.predict.annot_csv_filename)

--- a/tests/test_core/test_prep.py
+++ b/tests/test_core/test_prep.py
@@ -88,7 +88,6 @@ def test_prep(
         train_dur=cfg.prep.train_dur,
         val_dur=cfg.prep.val_dur,
         test_dur=cfg.prep.test_dur,
-        logger=None,
     )
 
     assert prep_output_matches_expected(csv_path, vak_df)
@@ -158,7 +157,6 @@ def test_prep_with_single_audio_and_annot(source_test_data_root,
         train_dur=cfg.prep.train_dur,
         val_dur=cfg.prep.val_dur,
         test_dur=cfg.prep.test_dur,
-        logger=None,
     )
 
     assert len(vak_df) == 1
@@ -217,7 +215,6 @@ def test_prep_when_annot_has_single_segment(source_test_data_root,
         train_dur=cfg.prep.train_dur,
         val_dur=cfg.prep.val_dur,
         test_dur=cfg.prep.test_dur,
-        logger=None,
     )
 
     assert len(vak_df) == 1

--- a/tests/test_core/test_train.py
+++ b/tests/test_core/test_train.py
@@ -73,7 +73,6 @@ def test_train(
         ckpt_step=cfg.train.ckpt_step,
         patience=cfg.train.patience,
         device=cfg.train.device,
-        logger=None,
     )
 
     assert train_output_matches_expected(cfg, model_config_map, results_path)
@@ -122,7 +121,6 @@ def test_continue_training(
         ckpt_step=cfg.train.ckpt_step,
         patience=cfg.train.patience,
         device=cfg.train.device,
-        logger=None,
     )
 
     assert train_output_matches_expected(cfg, model_config_map, results_path)


### PR DESCRIPTION
Fix logging so that log statements do not
repeat themselves (fixes #258).
To do this, we needed to remove all the logic
that passed loggers around between functions,
and instead use the stdlib logging module as intended,
as a singleton where child loggers pass messages
up to the root logger. Doing so produces a breaking change:
the `vak.engine.Model.from_config` method
no longer accepts a `logger` parameter.

This also refactors the logging module,
removing `get logger` and replacing it with
`config_log_for_cli`, which lets the cli
configure logging while at the same time
allowing users to configure logging how they want
when they are not using the cli.

--- squash commits ----

- Rewrite vak/logging.py module
  + Remove `log_or_print` function.
    Will now just use python Logger methods directly
  + Add `config_logging_for_cli` function.
    Allows the `cli` functions to call this to configure
    logging the way we run it now, and at the same time
    let users configure logging however they want when
    they are not using the cli
  + Use timenow.get_timenow_as_str in
    `config_logging_for_cli` function for timestamp
    - Add 'level' parameter and use to set logging level
    - Add a FormatHandler
    - Add force parameter, if True then remove handlers
      and add new ones
- Rewrite how cli modules configure logging
  + pass force=True into config_logging_for_cli
    inside all cli functions
- Make all other modules use stdlib for logging,
  by saying `logger = logging.getLogger(__name__)`
  outside of any functions, and then using that logger
  inside functions
  + This also involved removing `logger` parameters
    from functions, and removing any `logger` arguments
    in function calls
  + including a *Breaking change*: remove `logger` argument from
  `vak.engine.Model.from_config`
    - Remove logger parameter from vak.models.from_model_config_map
    - Remove logger parameter from TeenyTweetyNet.from_config method
    - Remove logger parameter from vak.split.train_test_dur_split_inds
- remove logger arguments from all function calls in tests