### PR TITLE
Fix prep error when labelset none

### DIFF
--- a/src/vak/core/prep.py
+++ b/src/vak/core/prep.py
@@ -153,13 +153,23 @@ def prep(
     if purpose == "predict":
         if labelset is not None:
             warnings.warn(
-                "purpose set to 'predict', but a labelset was provided."
+                ".toml config file has a 'predict' section, but a labelset was provided."
                 "This would cause an error because the dataframe.from_files section will attempt to "
                 f"check whether the files in the data_dir ({data_dir}) have labels in "
                 "labelset, even though those files don't have annotation.\n"
                 "Setting labelset to None."
             )
             labelset = None
+    else:  # if purpose is not predict
+        if labelset is None:
+            raise ValueError(
+                f".toml config file has a '{purpose}' section, but no labelset was provided."
+                "This will cause an error when trying to split the dataset, "
+                "e.g. into training and test splits, "
+                "or a silent error, e.g. when calculating metrics with an evaluation set. "
+                "Please add a 'labelset' option to the [PREP] section of the .toml config file."
+            )
+
     logger.info(f"purpose for dataset: {purpose}")
     # ---- figure out file name ----------------------------------------------------------------------------------------
     data_dir_name = data_dir.name

--- a/tests/fixtures/config.py
+++ b/tests/fixtures/config.py
@@ -120,6 +120,9 @@ def specific_config(generated_test_configs_root, list_of_schematized_configs, tm
         options_to_change : list, dict
             list of dicts with keys 'section', 'option', and 'value'.
             Can be a single dict, in which case only that option is changed.
+            If the 'value' is set to 'DELETE-OPTION',
+            the option will be removed from the config.
+            This can be used to test behavior when the option is not set.
 
         Returns
         -------
@@ -166,7 +169,11 @@ def specific_config(generated_test_configs_root, list_of_schematized_configs, tm
                 config_toml = toml.load(fp)
 
             for opt_dict in options_to_change:
-                config_toml[opt_dict["section"]][opt_dict["option"]] = opt_dict["value"]
+                if opt_dict["value"] == 'DELETE-OPTION':
+                    # e.g., to test behavior of config without this option
+                    del config_toml[opt_dict["section"]][opt_dict["option"]]
+                else:
+                    config_toml[opt_dict["section"]][opt_dict["option"]] = opt_dict["value"]
 
             with config_copy_path.open("w") as fp:
                 toml.dump(config_toml, fp)


### PR DESCRIPTION
Raises a ValueError when 'labelset' is left un-set in the .toml config file but the "purpose" of the config requires it, i.e., when the config has a "train", "learncurve" or "eval" section

Without this, an error will definitely result any time we try to split the dataset (as in #468) so this avoids expensive step of generating spectrograms + validating them before getting to that error later on

I think it could also have resulted in silent failures, e.g. by creating an evaluation set that, although it does not require a split, will contain labels not found in the training data, artificially inflating any error metrics

Fixes #468 