### PR TITLE
ENH: Have `core` not `config` check paths exist, fix #459

### DIFF
--- a/src/vak/config/eval.py
+++ b/src/vak/config/eval.py
@@ -1,9 +1,9 @@
 """parses [EVAL] section of config"""
 import attr
-from attr import converters, validators
+from attr import converters
 from attr.validators import instance_of
 
-from .validators import is_a_directory, is_a_file, is_valid_model_name
+from .validators import is_valid_model_name
 from .. import device
 from ..converters import comma_separated_list, expanded_user_path
 
@@ -37,11 +37,10 @@ class EvalConfig:
         If spectrograms were normalized and this is not provided, will give
         incorrect results.
     """
-
     # required, external files
-    checkpoint_path = attr.ib(converter=expanded_user_path, validator=is_a_file)
-    labelmap_path = attr.ib(converter=expanded_user_path, validator=is_a_file)
-    output_dir = attr.ib(converter=expanded_user_path, validator=is_a_directory)
+    checkpoint_path = attr.ib(converter=expanded_user_path)
+    labelmap_path = attr.ib(converter=expanded_user_path)
+    output_dir = attr.ib(converter=expanded_user_path)
 
     # required, model / dataloader
     models = attr.ib(
@@ -54,14 +53,12 @@ class EvalConfig:
     # what sections are defined to figure out where to add csv_path after it creates the csv
     csv_path = attr.ib(
         converter=converters.optional(expanded_user_path),
-        validator=validators.optional(is_a_file),
         default=None,
     )
 
     # optional, transform
     spect_scaler_path = attr.ib(
         converter=converters.optional(expanded_user_path),
-        validator=validators.optional(is_a_file),
         default=None,
     )
 

--- a/src/vak/config/learncurve.py
+++ b/src/vak/config/learncurve.py
@@ -1,9 +1,8 @@
 """parses [LEARNCURVE] section of config"""
 import attr
-from attr import converters, validators
+from attr import converters
 from attr.validators import instance_of
 
-from .validators import is_a_directory
 from .train import TrainConfig
 from ..converters import expanded_user_path
 
@@ -51,11 +50,9 @@ class LearncurveConfig(TrainConfig):
         path to results directory from a previous run.
         Used for training if use_train_subsets_from_previous_run is True.
     """
-
     train_set_durs = attr.ib(validator=instance_of(list), kw_only=True)
     num_replicates = attr.ib(validator=instance_of(int), kw_only=True)
     previous_run_path = attr.ib(
         converter=converters.optional(expanded_user_path),
-        validator=validators.optional(is_a_directory),
         default=None,
     )

--- a/src/vak/config/predict.py
+++ b/src/vak/config/predict.py
@@ -6,7 +6,7 @@ import attr
 from attr import converters, validators
 from attr.validators import instance_of
 
-from .validators import is_a_directory, is_a_file, is_valid_model_name
+from .validators import is_valid_model_name
 from .. import device
 from ..converters import comma_separated_list, expanded_user_path
 
@@ -71,8 +71,8 @@ class PredictConfig:
     """
 
     # required, external files
-    checkpoint_path = attr.ib(converter=expanded_user_path, validator=is_a_file)
-    labelmap_path = attr.ib(converter=expanded_user_path, validator=is_a_file)
+    checkpoint_path = attr.ib(converter=expanded_user_path)
+    labelmap_path = attr.ib(converter=expanded_user_path)
 
     # required, model / dataloader
     models = attr.ib(
@@ -85,14 +85,12 @@ class PredictConfig:
     # what sections are defined to figure out where to add csv_path after it creates the csv
     csv_path = attr.ib(
         converter=converters.optional(expanded_user_path),
-        validator=validators.optional(is_a_file),
         default=None,
     )
 
     # optional, transform
     spect_scaler_path = attr.ib(
         converter=converters.optional(expanded_user_path),
-        validator=validators.optional(is_a_file),
         default=None,
     )
 
@@ -105,7 +103,6 @@ class PredictConfig:
     )
     output_dir = attr.ib(
         converter=expanded_user_path,
-        validator=is_a_directory,
         default=Path(os.getcwd()),
     )
     min_segment_dur = attr.ib(

--- a/src/vak/config/prep.py
+++ b/src/vak/config/prep.py
@@ -4,8 +4,6 @@ from attr import converters, validators
 from attr.validators import instance_of
 
 from .validators import (
-    is_a_directory,
-    is_a_file,
     is_audio_format,
     is_annot_format,
     is_spect_format,
@@ -86,19 +84,17 @@ class PrepConfig:
         total duration of test set, in seconds.
     """
 
-    data_dir = attr.ib(converter=expanded_user_path, validator=is_a_directory)
-    output_dir = attr.ib(converter=expanded_user_path, validator=is_a_directory)
+    data_dir = attr.ib(converter=expanded_user_path)
+    output_dir = attr.ib(converter=expanded_user_path)
 
     audio_format = attr.ib(validator=validators.optional(is_audio_format), default=None)
     spect_format = attr.ib(validator=validators.optional(is_spect_format), default=None)
     spect_output_dir = attr.ib(
         converter=converters.optional(expanded_user_path),
-        validator=validators.optional(is_a_directory),
         default=None,
     )
     annot_file = attr.ib(
         converter=converters.optional(expanded_user_path),
-        validator=validators.optional(is_a_file),
         default=None,
     )
     annot_format = attr.ib(validator=validators.optional(is_annot_format), default=None)

--- a/src/vak/config/train.py
+++ b/src/vak/config/train.py
@@ -3,7 +3,7 @@ import attr
 from attr import converters, validators
 from attr.validators import instance_of
 
-from .validators import is_a_directory, is_a_file, is_valid_model_name
+from .validators import is_valid_model_name
 from .. import device
 from ..converters import bool_from_str, comma_separated_list, expanded_user_path
 
@@ -65,7 +65,6 @@ class TrainConfig:
     labelmap_path : str
         path to 'labelmap.json' file. Default is None.
     """
-
     # required
     models = attr.ib(
         converter=comma_separated_list,
@@ -73,20 +72,18 @@ class TrainConfig:
     )
     num_epochs = attr.ib(converter=int, validator=instance_of(int))
     batch_size = attr.ib(converter=int, validator=instance_of(int))
-    root_results_dir = attr.ib(converter=expanded_user_path, validator=is_a_directory)
+    root_results_dir = attr.ib(converter=expanded_user_path)
 
     # optional
     # csv_path is actually 'required' but we can't enforce that here because cli.prep looks at
     # what sections are defined to figure out where to add csv_path after it creates the csv
     csv_path = attr.ib(
         converter=converters.optional(expanded_user_path),
-        validator=validators.optional(is_a_file),
         default=None,
     )
 
     results_dirname = attr.ib(
         converter=converters.optional(expanded_user_path),
-        validator=validators.optional(is_a_directory),
         default=None,
     )
 
@@ -119,16 +116,13 @@ class TrainConfig:
     )
     checkpoint_path = attr.ib(
         converter=converters.optional(expanded_user_path),
-        validator=validators.optional(is_a_file),
         default=None,
     )
     spect_scaler_path = attr.ib(
         converter=converters.optional(expanded_user_path),
-        validator=validators.optional(is_a_file),
         default=None,
     )
     labelmap_path = attr.ib(
         converter=converters.optional(expanded_user_path),
-        validator=validators.optional(is_a_file),
         default=None,
     )

--- a/src/vak/core/eval.py
+++ b/src/vak/core/eval.py
@@ -72,12 +72,22 @@ def eval(
         Device on which to work with model + data.
         Defaults to 'cuda' if torch.cuda.is_available is True.
     """
-    if not validators.is_a_file(csv_path):
-        raise FileNotFoundError(
-            f'value for csv_path not recognized as a file: {csv_path}'
+    # ---- pre-conditions ----------------------------------------------------------------------------------------------
+    for path, path_name in zip(
+            (checkpoint_path, csv_path, labelmap_path, spect_scaler_path),
+            ('checkpoint_path', 'csv_path', 'labelmap_path', 'spect_scaler_path'),
+    ):
+        if path is not None:  # because `spect_scaler_path` is optional
+            if not validators.is_a_file(path):
+                raise FileNotFoundError(
+                    f"value for ``{path_name}`` not recognized as a file: {csv_path}"
+                )
+    if not validators.is_a_directory(output_dir):
+        raise NotADirectoryError(
+            f'value for ``output_dir`` not recognized as a directory: {output_dir}'
         )
 
-    # ---- get time for .csv file --------------------------------------------------------------------------
+    # ---- get time for .csv file --------------------------------------------------------------------------------------
     timenow = datetime.now().strftime("%y%m%d_%H%M%S")
 
     # ---------------- load data for evaluation ------------------------------------------------------------------------

--- a/src/vak/core/predict.py
+++ b/src/vak/core/predict.py
@@ -104,10 +104,15 @@ def predict(
          and the network is `TweetyNet`, then the net output file
          will be `gy6or6_032312_081416.tweetynet.output.npz`.
     """
-    if not validators.is_a_file(csv_path):
-        raise FileNotFoundError(
-            f'value for csv_path not recognized as a file: {csv_path}'
-        )
+    for path, path_name in zip(
+            (checkpoint_path, csv_path, labelmap_path, spect_scaler_path),
+            ('checkpoint_path', 'csv_path', 'labelmap_path', 'spect_scaler_path'),
+    ):
+        if path is not None:
+            if not validators.is_a_file(path):
+                raise FileNotFoundError(
+                    f"value for ``{path_name}`` not recognized as a file: {csv_path}"
+                )
 
     if output_dir is None:
         output_dir = Path(os.getcwd())

--- a/src/vak/core/prep.py
+++ b/src/vak/core/prep.py
@@ -150,6 +150,13 @@ def prep(
         if not spect_output_dir.is_dir():
             raise NotADirectoryError(f"spect_output_dir not found: {spect_output_dir}")
 
+    if annot_file is not None:
+        annot_file = expanded_user_path(annot_file)
+        if not annot_file.exists():
+            raise FileNotFoundError(
+                f'annot_file not found: {annot_file}'
+            )
+
     if purpose == "predict":
         if labelset is not None:
             warnings.warn(

--- a/src/vak/core/train.py
+++ b/src/vak/core/train.py
@@ -66,7 +66,7 @@ def train(
         path to where dataset was saved as a csv.
     window_size : int
         size of windows taken from spectrograms, in number of time bins,
-        shonw to neural networks
+        shown to neural networks
     batch_size : int
         number of samples per batch presented to models during training.
     num_epochs : int
@@ -149,10 +149,15 @@ def train(
         validation set improving before stopping the training.
         Default is None, in which case training only stops after the specified number of epochs.
     """
-    if not validators.is_a_file(csv_path):
-        raise FileNotFoundError(
-            f'value for csv_path not recognized as a file: {csv_path}'
-        )
+    for path, path_name in zip(
+            (checkpoint_path, csv_path, labelmap_path, spect_scaler_path),
+            ('checkpoint_path', 'csv_path', 'labelmap_path', 'spect_scaler_path'),
+    ):
+        if path is not None:
+            if not validators.is_a_file(path):
+                raise FileNotFoundError(
+                    f"value for ``{path_name}`` not recognized as a file: {csv_path}"
+                )
 
     logger.info(
         f"Loading dataset from .csv path: {csv_path}",

--- a/tests/fixtures/config.py
+++ b/tests/fixtures/config.py
@@ -86,7 +86,7 @@ def specific_config(generated_test_configs_root, list_of_schematized_configs, tm
 
     The factory function actually returns a copy,
     that will be copied into ``tmp_path``,
-    so the original remains umodified.
+    so the original remains unmodified.
 
     If ``root_results_dir`` argument is specified
     when calling the factory function,

--- a/tests/test_config/test_eval.py
+++ b/tests/test_config/test_eval.py
@@ -1,0 +1,10 @@
+"""tests for vak.config.eval module"""
+import vak.config.eval
+
+
+def test_predict_attrs_class(all_generated_eval_configs_toml):
+    """test that instantiating EvalConfig class works as expected"""
+    for config_toml in all_generated_eval_configs_toml:
+        eval_section = config_toml["EVAL"]
+        config = vak.config.eval.EvalConfig(**eval_section)
+        assert isinstance(config, vak.config.eval.EvalConfig)

--- a/tests/test_core/test_eval.py
+++ b/tests/test_core/test_eval.py
@@ -63,11 +63,25 @@ def test_eval(
     assert eval_output_matches_expected(model_config_map, output_dir)
 
 
-def test_eval_invalid_csv_path_raises(
-    specific_config, tmp_path, device
+@pytest.mark.parametrize(
+    'path_option_to_change',
+    [
+        {"section": "EVAL", "option": "checkpoint_path", "value": '/obviously/doesnt/exist/ckpt.pt'},
+        {"section": "EVAL", "option": "labelmap_path", "value": '/obviously/doesnt/exist/labelmap.json'},
+        {"section": "EVAL", "option": "csv_path", "value": '/obviously/doesnt/exist/dataset.csv'},
+        {"section": "EVAL", "option": "spect_scaler_path", "value": '/obviously/doesnt/exist/SpectScaler'},
+    ]
+)
+def test_eval_raises_file_not_found(
+    path_option_to_change,
+    specific_config,
+    tmp_path,
+    device
 ):
     """Test that core.eval raises FileNotFoundError
-    when `csv_path` does not exist."""
+    when one of the following does not exist:
+    checkpoint_path, labelmap_path, csv_path, spect_scaler_path
+    """
     output_dir = tmp_path.joinpath(
         f"test_eval_cbin_notmat_invalid_csv_path"
     )
@@ -75,6 +89,45 @@ def test_eval_invalid_csv_path_raises(
 
     options_to_change = [
         {"section": "EVAL", "option": "output_dir", "value": str(output_dir)},
+        {"section": "EVAL", "option": "device", "value": device},
+        path_option_to_change,
+    ]
+
+    toml_path = specific_config(
+        config_type="eval",
+        model="teenytweetynet",
+        audio_format="cbin",
+        annot_format="notmat",
+        spect_format=None,
+        options_to_change=options_to_change,
+    )
+    cfg = vak.config.parse.from_toml_path(toml_path)
+    model_config_map = vak.config.models.map_from_path(toml_path, cfg.eval.models)
+    with pytest.raises(FileNotFoundError):
+        vak.core.eval(
+            csv_path=cfg.eval.csv_path,
+            model_config_map=model_config_map,
+            checkpoint_path=cfg.eval.checkpoint_path,
+            labelmap_path=cfg.eval.labelmap_path,
+            output_dir=cfg.eval.output_dir,
+            window_size=cfg.dataloader.window_size,
+            num_workers=cfg.eval.num_workers,
+            spect_scaler_path=cfg.eval.spect_scaler_path,
+            spect_key=cfg.spect_params.spect_key,
+            timebins_key=cfg.spect_params.timebins_key,
+            device=cfg.eval.device,
+        )
+
+
+def test_eval_raises_not_a_directory(
+    specific_config,
+    device
+):
+    """Test that core.eval raises NotADirectory
+    when ``output_dir`` does not exist
+    """
+    options_to_change = [
+        {"section": "EVAL", "option": "output_dir", "value": '/obviously/does/not/exist/output'},
         {"section": "EVAL", "option": "device", "value": device},
     ]
 
@@ -88,12 +141,10 @@ def test_eval_invalid_csv_path_raises(
     )
     cfg = vak.config.parse.from_toml_path(toml_path)
     model_config_map = vak.config.models.map_from_path(toml_path, cfg.eval.models)
-
-    invalid_csv_path = '/obviously/doesnt/exist/dataset.csv'
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(NotADirectoryError):
         vak.core.eval(
-            invalid_csv_path,
-            model_config_map,
+            csv_path=cfg.eval.csv_path,
+            model_config_map=model_config_map,
             checkpoint_path=cfg.eval.checkpoint_path,
             labelmap_path=cfg.eval.labelmap_path,
             output_dir=cfg.eval.output_dir,

--- a/tests/test_core/test_predict.py
+++ b/tests/test_core/test_predict.py
@@ -91,8 +91,20 @@ def test_predict(
             assert len(net_output_spect_path) == 1
 
 
-def test_predict_invalid_csv_path_raises(
-    specific_config, tmp_path, device
+@pytest.mark.parametrize(
+    'path_option_to_change',
+    [
+        {"section": "PREDICT", "option": "checkpoint_path", "value": '/obviously/doesnt/exist/ckpt.pt'},
+        {"section": "PREDICT", "option": "labelmap_path", "value": '/obviously/doesnt/exist/labelmap.json'},
+        {"section": "PREDICT", "option": "csv_path", "value": '/obviously/doesnt/exist/dataset.csv'},
+        {"section": "PREDICT", "option": "spect_scaler_path", "value": '/obviously/doesnt/exist/SpectScaler'},
+    ]
+)
+def test_predict_raises_file_not_found(
+    path_option_to_change,
+    specific_config,
+    tmp_path,
+    device
 ):
     """Test that core.eval raises FileNotFoundError
     when `csv_path` does not exist."""
@@ -104,6 +116,7 @@ def test_predict_invalid_csv_path_raises(
     options_to_change = [
         {"section": "PREDICT", "option": "output_dir", "value": str(output_dir)},
         {"section": "PREDICT", "option": "device", "value": device},
+        path_option_to_change,
     ]
     toml_path = specific_config(
         config_type="predict",
@@ -116,10 +129,50 @@ def test_predict_invalid_csv_path_raises(
 
     model_config_map = vak.config.models.map_from_path(toml_path, cfg.predict.models)
 
-    invalid_csv_path = '/obviously/doesnt/exist/dataset.csv'
     with pytest.raises(FileNotFoundError):
         vak.core.predict(
-            csv_path=invalid_csv_path,
+            csv_path=cfg.predict.csv_path,
+            checkpoint_path=cfg.predict.checkpoint_path,
+            labelmap_path=cfg.predict.labelmap_path,
+            model_config_map=model_config_map,
+            window_size=cfg.dataloader.window_size,
+            num_workers=cfg.predict.num_workers,
+            spect_key=cfg.spect_params.spect_key,
+            timebins_key=cfg.spect_params.timebins_key,
+            spect_scaler_path=cfg.predict.spect_scaler_path,
+            device=cfg.predict.device,
+            annot_csv_filename=cfg.predict.annot_csv_filename,
+            output_dir=cfg.predict.output_dir,
+            min_segment_dur=cfg.predict.min_segment_dur,
+            majority_vote=cfg.predict.majority_vote,
+            save_net_outputs=cfg.predict.save_net_outputs,
+        )
+
+
+def test_predict_raises_not_a_directory(
+    specific_config,
+    device
+):
+    """Test that core.eval raises NotADirectory
+    when ``output_dir`` does not exist
+    """
+    options_to_change = [
+        {"section": "PREDICT", "option": "output_dir", "value": '/obviously/does/not/exist/output'},
+        {"section": "PREDICT", "option": "device", "value": device},
+    ]
+    toml_path = specific_config(
+        config_type="predict",
+        model="teenytweetynet",
+        audio_format="cbin",
+        annot_format="notmat",
+        options_to_change=options_to_change,
+    )
+    cfg = vak.config.parse.from_toml_path(toml_path)
+    model_config_map = vak.config.models.map_from_path(toml_path, cfg.predict.models)
+
+    with pytest.raises(NotADirectoryError):
+        vak.core.predict(
+            csv_path=cfg.predict.csv_path,
             checkpoint_path=cfg.predict.checkpoint_path,
             labelmap_path=cfg.predict.labelmap_path,
             model_config_map=model_config_map,

--- a/tests/test_core/test_prep.py
+++ b/tests/test_core/test_prep.py
@@ -288,3 +288,98 @@ def test_prep_when_annot_has_single_segment(source_test_data_root,
     )
 
     assert len(vak_df) == 1
+
+
+@pytest.mark.parametrize(
+    "dir_option_to_change",
+    [
+        {"section": "PREP", "option": "data_dir", "value": '/obviously/does/not/exist/data'},
+        {"section": "PREP", "option": "output_dir", "value": '/obviously/does/not/exist/output'},
+        {"section": "PREP", "option": "spect_output_dir", "value": '/obviously/does/not/exist/spect_output'},
+    ],
+)
+def test_prep_raises_not_a_directory(
+    dir_option_to_change,
+    specific_config,
+    default_model,
+    tmp_path,
+):
+    """Test that `core.prep` raise NotADirectory error
+    when one of the following is not a directory:
+    data_dir, output_dir, spect_output_dir
+    """
+    toml_path = specific_config(
+        config_type="train",
+        model="teenytweetynet",
+        audio_format="cbin",
+        annot_format="notmat",
+        spect_format=None,
+        options_to_change=dir_option_to_change,
+    )
+    cfg = vak.config.parse.from_toml_path(toml_path)
+
+    purpose = "train"
+    with pytest.raises(NotADirectoryError):
+        vak.core.prep(
+            data_dir=cfg.prep.data_dir,
+            purpose=purpose,
+            audio_format=cfg.prep.audio_format,
+            spect_format=cfg.prep.spect_format,
+            spect_output_dir=cfg.prep.spect_output_dir,
+            spect_params=cfg.spect_params,
+            annot_format=cfg.prep.annot_format,
+            annot_file=cfg.prep.annot_file,
+            labelset=cfg.prep.labelset,
+            output_dir=cfg.prep.output_dir,
+            train_dur=cfg.prep.train_dur,
+            val_dur=cfg.prep.val_dur,
+            test_dur=cfg.prep.test_dur,
+        )
+
+
+@pytest.mark.parametrize(
+    "path_option_to_change",
+    [
+        {"section": "PREP", "option": "annot_file", "value": '/obviously/does/not/exist/annot.mat'},
+    ],
+)
+def test_prep_raises_file_not_found(
+    path_option_to_change,
+    specific_config,
+    default_model,
+    tmp_path,
+):
+    """Test that `core.prep` raise FileNotFound error
+    when one of the following does not exist:
+    annot_file
+
+    Structuring unit test this way in case other path
+    parameters get added.
+    """
+    toml_path = specific_config(
+        config_type="train",
+        model="teenytweetynet",
+        audio_format="cbin",
+        annot_format="notmat",
+        spect_format=None,
+        options_to_change=path_option_to_change,
+    )
+    cfg = vak.config.parse.from_toml_path(toml_path)
+
+    purpose = "train"
+    with pytest.raises(FileNotFoundError):
+        vak.core.prep(
+            data_dir=cfg.prep.data_dir,
+            purpose=purpose,
+            audio_format=cfg.prep.audio_format,
+            spect_format=cfg.prep.spect_format,
+            spect_output_dir=cfg.prep.spect_output_dir,
+            spect_params=cfg.spect_params,
+            annot_format=cfg.prep.annot_format,
+            annot_file=cfg.prep.annot_file,
+            labelset=cfg.prep.labelset,
+            output_dir=cfg.prep.output_dir,
+            train_dur=cfg.prep.train_dur,
+            val_dur=cfg.prep.val_dur,
+            test_dur=cfg.prep.test_dur,
+        )

--- a/tests/test_core/test_train.py
+++ b/tests/test_core/test_train.py
@@ -126,11 +126,25 @@ def test_continue_training(
     assert train_output_matches_expected(cfg, model_config_map, results_path)
 
 
-def test_train_invalid_csv_path_raises(
-    specific_config, tmp_path, device
+@pytest.mark.parametrize(
+    'path_option_to_change',
+    [
+        {"section": "TRAIN", "option": "checkpoint_path", "value": '/obviously/doesnt/exist/ckpt.pt'},
+        {"section": "TRAIN", "option": "labelmap_path", "value": '/obviously/doesnt/exist/labelmap.json'},
+        {"section": "TRAIN", "option": "csv_path", "value": '/obviously/doesnt/exist/dataset.csv'},
+        {"section": "TRAIN", "option": "spect_scaler_path", "value": '/obviously/doesnt/exist/SpectScaler'},
+    ]
+)
+def test_train_raises_file_not_found(
+    path_option_to_change, specific_config, tmp_path, device
 ):
+    """Test that pre-conditions in `vak.core.train` raise FileNotFoundError
+    when one of the following does not exist:
+    checkpoint_path, labelmap_path, csv_path, spect_scaler_path
+    """
     options_to_change = [
-        {"section": "TRAIN", "option": "device", "value": device}
+        {"section": "TRAIN", "option": "device", "value": device},
+        path_option_to_change
     ]
     toml_path = specific_config(
         config_type="train",
@@ -145,16 +159,66 @@ def test_train_invalid_csv_path_raises(
     results_path = vak.paths.generate_results_dir_name_as_path(tmp_path)
     results_path.mkdir()
 
-    invalid_csv_path = '/obviously/doesnt/exist/dataset.csv'
     with pytest.raises(FileNotFoundError):
         vak.core.train(
-            model_config_map,
-            invalid_csv_path,
-            cfg.dataloader.window_size,
-            cfg.train.batch_size,
-            cfg.train.num_epochs,
-            cfg.train.num_workers,
+            model_config_map=model_config_map,
+            csv_path=cfg.train.csv_path,
+            window_size=cfg.dataloader.window_size,
+            batch_size=cfg.train.batch_size,
+            num_epochs=cfg.train.num_epochs,
+            num_workers=cfg.train.num_workers,
             labelset=cfg.prep.labelset,
+            labelmap_path=cfg.train.labelmap_path,
+            checkpoint_path=cfg.train.checkpoint_path,
+            spect_scaler_path=cfg.train.spect_scaler_path,
+            results_path=results_path,
+            spect_key=cfg.spect_params.spect_key,
+            timebins_key=cfg.spect_params.timebins_key,
+            normalize_spectrograms=cfg.train.normalize_spectrograms,
+            shuffle=cfg.train.shuffle,
+            val_step=cfg.train.val_step,
+            ckpt_step=cfg.train.ckpt_step,
+            patience=cfg.train.patience,
+            device=cfg.train.device,
+        )
+
+
+def test_train_raises_not_a_directory(
+    specific_config, device
+):
+    """Test that core.train raises NotADirectory
+    when ``results_path`` does not exist
+    """
+    options_to_change = [
+        {"section": "TRAIN", "option": "root_results_dir", "value": '/obviously/doesnt/exist/results/'},
+        {"section": "TRAIN", "option": "device", "value": device},
+    ]
+    toml_path = specific_config(
+        config_type="train",
+        model="teenytweetynet",
+        audio_format="cbin",
+        annot_format="notmat",
+        spect_format=None,
+        options_to_change=options_to_change,
+    )
+    cfg = vak.config.parse.from_toml_path(toml_path)
+    model_config_map = vak.config.models.map_from_path(toml_path, cfg.train.models)
+
+    # mock behavior of cli.train, building `results_path` from config option `root_results_dir`
+    results_path = cfg.train.root_results_dir / 'results-dir-timestamp'
+
+    with pytest.raises(NotADirectoryError):
+        vak.core.train(
+            model_config_map=model_config_map,
+            csv_path=cfg.train.csv_path,
+            window_size=cfg.dataloader.window_size,
+            batch_size=cfg.train.batch_size,
+            num_epochs=cfg.train.num_epochs,
+            num_workers=cfg.train.num_workers,
+            labelset=cfg.prep.labelset,
+            labelmap_path=cfg.train.labelmap_path,
+            checkpoint_path=cfg.train.checkpoint_path,
+            spect_scaler_path=cfg.train.spect_scaler_path,
             results_path=results_path,
             spect_key=cfg.spect_params.spect_key,
             timebins_key=cfg.spect_params.timebins_key,


### PR DESCRIPTION
Having the `config` `attrs` classes validate that paths exist makes it difficult to work with config files, e.g. to programatically extract metadata about experiments that have already been run, as described in #459.

Instead of doing this, `config` classes should merely convert to appropriate types, but let other parts of `vak` handle any validation.

Change `vak.core` functions to do this validation instead. This involves sticking in a lot of pre-conditions that check if parameters that are files or directories exist. This may seem un-Pythonic, because it is not duck-typing, but the goal is to give users who may not be programmers very clear feedback about what caused a crash.

Squash commits:
- Remove is_a_file + is_a_dir validators from config classes
  + Remove is_a_file + is_a_dir validators in config/eval.py
  + Remove is_a_file + is_a_dir validators in config/train.py
  + Remove is_a_file + is_a_dir validators in config/predict.py
  + Remove is_a_file + is_a_dir validators in config/prep.py
  + Remove is_a_dir validators in config/learncurve.py
- Make `core` functions do validation
  + Check file + dir paths exist at top of core/eval.py
  + Check file + dir paths exist at top of core/train.py
  + Check file + dir paths exist at top of core/predict.py
  + Make core/prep.py check if annot_file exists
- Fix tests after making changes
  + TST: Add tests/test_config/test_eval.py
  + TST: Add unit tests that vak.core.eval raises errors as expected
  + TST: Add/revise unit tests that vak.core.train
    raises errors as expected
  + TST: Add/revise unit tests that vak.core.predict
    raises errors as expected
  + TST: Add/revise unit tests that vak.core.prep
    raises errors as expected
  + TST: Add/revise unit tests that vak.core.learncurve
    raises errors as expected
  + TST: Rewrite tests/test_config/test_parse.py
    - Remove all tests that asserted that
      FileNotFoundError and NotADirectoryError
      were raised by attributes with non-existent
      files/directories
    - Rewrite unit test that was meant to test the
      `sections` parameter of the `config.parse.from_toml`
      function -- had a similar `raises` assert,
      but also was just in general not clearly named / written.
- Other:
  + DOC: Fix typo in fixtures/config.py docstring