### PR TITLE
ENH: `prep` raises error when dataframe is empty, fix #116 [skip ci]

### DIFF
--- a/src/vak/core/prep.py
+++ b/src/vak/core/prep.py
@@ -226,6 +226,13 @@ def prep(
         spect_params=spect_params,
     )
 
+    if vak_df.empty:
+        raise ValueError(
+            "Calling `vak.io.dataframe.from_files` with arguments passed to `vak.core.prep` "
+            "returned an empty dataframe.\n"
+            "Please double-check arguments to `vak.core.prep` function."
+        )
+
     if do_split:
         # save before splitting, jic duration args are not valid (we can't know until we make dataset)
         vak_df.to_csv(csv_path)


### PR DESCRIPTION
Have `vak.core.prep` raise ValueError if `vak_df` returned by `dataframe.from_files` is empty.
Fixes #116.

I was unable to reliably find a way to cause this error -- I should have put more detail in that issue when I raised it.
So I am not adding a unit test for this.

But it still seems better to raise an error than to not, since a user will be expecting the dataset to not be "empty", and we don't want it to fail silently, or cause an even more cryptic error downstream.