### PR TITLE
Rename and refactor `recursive_stem`, add clearer error messages in vak/annotation.py

### DIFF
--- a/src/vak/datasets/window_dataset.py
+++ b/src/vak/datasets/window_dataset.py
@@ -674,7 +674,7 @@ class WindowDataset(VisionDataset):
 
         if crop_to_dur:
             lbl_tb = []
-            spect_annot_map = annotation.source_annot_map(spect_paths, annots)
+            spect_annot_map = annotation.map_annotated_to_annot(spect_paths, annots)
             for ind, (spect_path, annot) in enumerate(spect_annot_map.items()):
                 spect_dict = files.spect.load(spect_path)
                 n_tb_spect = spect_dict[spect_key].shape[-1]

--- a/src/vak/io/audio.py
+++ b/src/vak/io/audio.py
@@ -10,7 +10,7 @@ from .. import (
     constants,
     files
 )
-from ..annotation import source_annot_map
+from ..annotation import map_annotated_to_annot
 from ..converters import labelset_to_set
 from ..config.spect_params import SpectParamsConfig
 from ..spect import spectrogram
@@ -170,13 +170,13 @@ def to_spect(
                 )
 
         if annot_list:  # make map we can validate below
-            audio_annot_map = source_annot_map(audio_files, annot_list)
+            audio_annot_map = map_annotated_to_annot(audio_files, annot_list)
 
     # otherwise get audio files using audio dir (won't need to validate audio files)
     if audio_dir:
         audio_files = files_from_dir(audio_dir, audio_format)
         if annot_list:
-            audio_annot_map = source_annot_map(audio_files, annot_list)
+            audio_annot_map = map_annotated_to_annot(audio_files, annot_list)
 
     logger.info("creating array files with spectrograms")
 

--- a/src/vak/io/spect.py
+++ b/src/vak/io/spect.py
@@ -15,7 +15,7 @@ import pandas as pd
 
 from .. import constants
 from .. import files
-from ..annotation import source_annot_map
+from ..annotation import map_annotated_to_annot
 from ..converters import labelset_to_set
 
 
@@ -162,7 +162,7 @@ def to_dataframe(
 
     if spect_files:  # (or if we just got them from spect_dir)
         if annot_list:
-            spect_annot_map = source_annot_map(spect_files, annot_list)
+            spect_annot_map = map_annotated_to_annot(spect_files, annot_list)
         else:
             # no annotation, so map spectrogram files to None
             spect_annot_map = dict((spect_path, None) for spect_path in spect_files)

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -23,7 +23,7 @@ def test_files_from_dir(annot_dir_notmat, annot_files_notmat):
         ("spect", "mat", "yarden"),
     ],
 )
-def test_source_annot_map(
+def test_annotated_annot_map(
     source_type,
     source_format,
     annot_format,
@@ -32,26 +32,26 @@ def test_source_annot_map(
     specific_annot_list,
 ):
     if source_type == "audio":
-        source_files = audio_list_factory(source_format)
+        annotated_files = audio_list_factory(source_format)
     else:
-        source_files = spect_list_mat
+        annotated_files = spect_list_mat
     annot_list = specific_annot_list(annot_format)
-    source_annot_map = vak.annotation.map_annotated_to_annot(
-        source_files=source_files, annot_list=annot_list
+    annotated_annot_map = vak.annotation.map_annotated_to_annot(
+        annotated_files=annotated_files, annot_list=annot_list
     )
 
     # test all the audio paths made it into the map
-    source_files_from_map = list(source_annot_map.keys())
-    for source_file in source_files:
-        assert source_file in source_files_from_map
+    annotated_files_from_map = list(annotated_annot_map.keys())
+    for source_file in annotated_files:
+        assert source_file in annotated_files_from_map
 
     # test all the annots made it into the map
-    annot_list_from_map = list(source_annot_map.values())
+    annot_list_from_map = list(annotated_annot_map.values())
     for annot in annot_list:
         assert annot in annot_list_from_map
 
     # test all mappings are correct
-    for source_path, annot in list(source_annot_map.items()):
+    for source_path, annot in list(annotated_annot_map.items()):
         assert vak.annotation.audio_stem_from_path(
             annot.audio_path
         ) == vak.annotation.audio_stem_from_path(source_path)

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -36,7 +36,7 @@ def test_source_annot_map(
     else:
         source_files = spect_list_mat
     annot_list = specific_annot_list(annot_format)
-    source_annot_map = vak.annotation.source_annot_map(
+    source_annot_map = vak.annotation.map_annotated_to_annot(
         source_files=source_files, annot_list=annot_list
     )
 
@@ -52,9 +52,9 @@ def test_source_annot_map(
 
     # test all mappings are correct
     for source_path, annot in list(source_annot_map.items()):
-        assert vak.annotation.recursive_stem(
+        assert vak.annotation.audio_stem_from_path(
             annot.audio_path
-        ) == vak.annotation.recursive_stem(source_path)
+        ) == vak.annotation.audio_stem_from_path(source_path)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_labeled_timebins.py
+++ b/tests/test_labeled_timebins.py
@@ -189,7 +189,7 @@ def test_lbl_tb2segments_recovers_onsets_offsets_labels_from_real_data(
 
     spect_paths = vak_df["spect_path"].values
     annot_list = vak.annotation.from_df(vak_df)
-    spect_annot_map = vak.annotation.source_annot_map(spect_paths, annot_list)
+    spect_annot_map = vak.annotation.map_annotated_to_annot(spect_paths, annot_list)
 
     TIMEBINS_KEY = "t"
 


### PR DESCRIPTION
Fixes #525, addresses issues discussed in #523.