### PR TITLE
Update autoannotate

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -51,6 +51,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx_copybutton',
     'sphinxext.opengraph',
+    'sphinx_tabs.tabs'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/get_started/autoannotate.md
+++ b/doc/get_started/autoannotate.md
@@ -36,32 +36,45 @@ don't worry, it will all be explained in the following sections.
 
 Before going through this tutorial, you'll need to:
 
-1. have `vak` installed (following these {ref}`instructions <installation>`).
-2. have a text editor to change a few options in the configuration files
+1. Have `vak` installed (following these {ref}`instructions <installation>`).
+2. Have a text editor to change a few options in the configuration files
    such as [sublime](https://www.sublimetext.com/), [gedit](https://wiki.gnome.org/Apps/Gedit),
    or [notepad++](https://notepad-plus-plus.org/)
-3. download example data (from this dataset: <https://figshare.com/articles/Bengalese_Finch_song_repository/4805749> )
+3. Download example data from this dataset: <https://figshare.com/articles/Bengalese_Finch_song_repository/4805749>
 
    - one day of birdsong, for training data (click to download)  
-     {download}`https://ndownloader.figshare.com/files/9537229`
-   - another day, to use to predict annnotations (click to download)
-     {download}`https://ndownloader.figshare.com/files/9537232`
-   - Be sure to extract the files from these archives!
-     On Windows you can use programs like [WinRAR](https://www.rarlab.com/)
-     or [WinZIP](https://www.winzip.com/win/en/tar-gz-file.html),
-     on mac you can double click the `.tar.gz` file, and on
-     (Ubuntu) linux you can right-click and select the `Extract to` option.
+     {download}`https://figshare.com/ndownloader/files/37509160`
+   - another day, to use to predict annotations (click to download)
+     {download}`https://figshare.com/ndownloader/files/37509172`
+   - Be sure to extract the files from these archives! 
+     Please use the program "tar" to extract the archives, 
+     on either macOS/Linux or Windows.
+     Using other programs like WinZIP on Windows 
+     can corrupt the files when extracting them,
+     causing confusing errors.
+     Tar should be available on newer Windows systems
+     (as described 
+     [here](https://learn.microsoft.com/en-us/virtualization/community/team-blog/2017/20171219-tar-and-curl-come-to-windows)).
+   - Alternatively you can copy the following command and then 
+     paste it into a terminal to run a Python script 
+     that will download and extract the files for you. 
 
-4. download the corresponding configuration files (click to download):
+     :::{eval-rst}
+    
+     .. tabs::
+    
+        .. code-tab:: shell macOS / Linux
+    
+           curl -sSL https://raw.githubusercontent.com/vocalpy/vak/main/src/scripts/download_autoannotate_data.py | python3 -
+     
+        .. code-tab:: shell Windows
+    
+           (Invoke-WebRequest -Uri https://raw.githubusercontent.com/vocalpy/vak/main/src/scripts/download_autoannotate_data.py -UseBasicParsing).Content | py -
+     :::
+
+4. Download the corresponding configuration files (click to download):
    {download}`gy6or6_train.toml <../toml/gy6or6_train.toml>`
    and {download}`gy6or6_predict.toml <../toml/gy6or6_predict.toml>`
-
-:::{note}
-This tutorial uses audio files in a `.cbin` format. 
-The `vak` library can load common audio formats (WAV, FLAC, OGG).
-If you are wondering about the `.cbin` format, 
-please see <https://github.com/NickleDave/evfuncs>.
-:::
 
 ## Overview
 

--- a/doc/toml/gy6or6_predict.toml
+++ b/doc/toml/gy6or6_predict.toml
@@ -1,7 +1,7 @@
 [PREP]
 data_dir = "/PATH/TO/DATA/032312"
 output_dir = "/PATH/TO/DATA/vak/prep/predict"
-audio_format = "cbin"
+audio_format = "wav"
 
 [SPECT_PARAMS]
 fft_size = 512

--- a/doc/toml/gy6or6_train.toml
+++ b/doc/toml/gy6or6_train.toml
@@ -1,8 +1,8 @@
 [PREP]
 data_dir = "/PATH/TO/DATA/032212"
 output_dir = "/PATH/TO/DATA/vak/prep/train"
-audio_format = "cbin"
-annot_format = "notmat"
+audio_format = "wav"
+annot_format = "simple-seq"
 labelset = "iabcdefghjk"
 train_dur = 50
 val_dur = 15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,9 +56,10 @@ doc = [
     "furo >=2022.1.2",
     "myst-parser >=0.17.0",
     "sphinx >=3.4.1",
-    "sphinxext-opengraph  >=0.5.1",
+    "sphinxext-opengraph >=0.5.1",
+    "sphinx-autobuild >=2021.3.14",
     "sphinx-copybutton >=0.4.0",
-    "sphinx-autobuild >= 2021.3.14",
+    "sphinx-tabs >=3.4.1",
 ]
 
 [project.urls]

--- a/src/scripts/download_autoannoate_data.py
+++ b/src/scripts/download_autoannoate_data.py
@@ -1,0 +1,128 @@
+"""script to download sample data for vak autoannotate tutorial
+
+Adapted from
+https://github.com/NickleDave/bfsongrepo/blob/main/src/scripts/download_dataset.py
+"""
+import argparse
+import pathlib
+import shutil
+import sys
+import time
+import urllib.request
+import warnings
+
+
+DATA_TO_DOWNLOAD = {
+    "gy6or6": {
+        "sober.repo1.gy6or6.032212.wav.csv.tar.gz": {
+            "MD5": "8c88b46ba87f9784d3690cc8ee4bf2f4",
+            "download": "https://figshare.com/ndownloader/files/37509160"
+        },
+        "sober.repo1.gy6or6.032312.wav.csv.tar.gz": {
+            "MD5": "063ba4d50d1b94009b4b00f0a941d098",
+            "download": "https://figshare.com/ndownloader/files/37509172"
+        }
+    }
+}
+
+
+def reporthook(count, block_size, total_size):
+    """hook for urlretrieve that gives us a simple progress report
+    https://blog.shichao.io/2012/10/04/progress_speed_indicator_for_urlretrieve_in_python.html
+    """
+    global start_time
+    if count == 0:
+        start_time = time.time()
+        return
+    duration = time.time() - start_time
+    progress_size = int(count * block_size)
+    speed = int(progress_size / (1024 * duration))
+    percent = int(count * block_size * 100 / total_size)
+    sys.stdout.write("\r...%d%%, %d MB, %d KB/s, %d seconds passed" %
+                    (percent, progress_size / (1024 * 1024), speed, duration))
+    sys.stdout.flush()
+
+
+def download_dataset(download_urls_by_bird_ID: dict,
+                     bfsongrepo_dir: pathlib.Path) -> None:
+    """download the dataset, given a dict of download urls"""
+    tar_dir = bfsongrepo_dir / "tars"
+    tar_dir.mkdir()
+    # top-level keys are bird ID: bl26lb16, gr41rd51, ...
+    for bird_id, tars_dict in download_urls_by_bird_ID.items():
+        print(
+            f'Downloading .tar files for bird: {bird_id}'
+        )
+        # bird ID -> dict where keys are .tar.gz filenames mapping to download url + MD5 hash
+        for tar_name, url_md5_dict in tars_dict.items():
+            print(
+                f'Downloading tar: {tar_name}'
+            )
+            download_url = url_md5_dict['download']
+            filename = tar_dir / tar_name
+            urllib.request.urlretrieve(download_url, filename, reporthook)
+            print('\n')
+
+
+def extract_tars(bfsongrepo_dir: pathlib.Path) -> None:
+    tar_dir = bfsongrepo_dir / "tars"  # made by download_dataset function
+    tars = sorted(tar_dir.glob('*.tar.gz'))
+    for tar_path in tars:
+        print(
+            f"\nunpacking: {tar_path}"
+        )
+
+        shutil.unpack_archive(
+            filename=tar_path,
+            extract_dir=bfsongrepo_dir,
+            format="gztar"
+        )
+
+
+def main(dst: str | pathlib.Path) -> None:
+    """main function that downloads and extracts entire dataset"""
+    dst = pathlib.Path(dst).expanduser().resolve()
+    if not dst.is_dir():
+        raise NotADirectoryError(
+            f"Value for 'dst' argument not recognized as a directory: {dst}"
+        )
+    bfsongrepo_dir = dst / 'bfsongrepo'
+    if bfsongrepo_dir.exists():
+        warnings.warn(
+            f"Directory already exists: {bfsongrepo_dir}\n"
+            "Will download and write over any existing files. Press Ctrl-C to stop."
+        )
+
+    try:
+        bfsongrepo_dir.mkdir(exist_ok=True)
+    except PermissionError as e:
+        raise PermissionError(
+            f"Unable to create directory in 'dst': {dst}\n"
+            "Please try running with 'sudo' on Unix systems or as Administrator on Windows systems.\n"
+            "If that fails, please download files for tutorial manually from the 'download' links in tutorial page."
+        ) from e
+
+    print(
+        f'Downloading Bengalese Finch Song Repository to: {bfsongrepo_dir}'
+    )
+
+    download_dataset(DATA_TO_DOWNLOAD, bfsongrepo_dir)
+    extract_tars(bfsongrepo_dir)
+
+
+def get_parser():
+    """get ArgumentParser used to parse command-line arguments"""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--dst',
+        default='.',
+        help=("Destination where dataset should be downloaded. "
+              "Default is '.', i.e., current working directory "
+              "from which this script is run.'")
+    )
+    return parser
+
+
+parser = get_parser()
+args = parser.parse_args()
+main(dst=args.dst)


### PR DESCRIPTION
- Specify that tar should be used to extract .tar.gz files of data for tutorial
- Add script that can download and extract files (e.g. for users without easy access to tar), and include snipped to run script in tutorial
- Use version of BFSongRepo dataset with .wav audio and .csv annotations

Fixes #560 and #576