### PR TITLE
ENH: Make files functions handle filename arguments with spaces in them, fix #589

### DIFF
--- a/src/vak/files/files.py
+++ b/src/vak/files/files.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
 import fnmatch
 from pathlib import Path
 import re
 
 
-def find_fname(fname, ext):
+def find_fname(fname: str, ext: str) -> str | None:
     """given a file extension, finds a filename with that extension within
     another filename. Useful to find e.g. names of audio files in
     names of spectrogram files.
@@ -21,10 +22,10 @@ def find_fname(fname, ext):
 
     Examples
     --------
-    >>> sub_fname(fname='llb3_0003_2018_04_23_14_18_54.wav.mat', ext='wav')
+    >>> vak.files.find_fname(fname='llb3_0003_2018_04_23_14_18_54.wav.mat', ext='wav')
     'llb3_0003_2018_04_23_14_18_54.wav'
     """
-    m = re.match(f"[\S]*{ext}", fname)
+    m = re.match(f"[\S ]*{ext}", fname)
     if hasattr(m, "group"):
         return m.group()
     elif m is None:

--- a/tests/fixtures/audio.py
+++ b/tests/fixtures/audio.py
@@ -1,6 +1,8 @@
 """fixtures relating to audio files"""
 import pytest
 
+from .test_data import SOURCE_TEST_DATA_ROOT
+
 
 @pytest.fixture
 def default_spect_params():
@@ -17,14 +19,20 @@ def default_spect_params():
     )
 
 
-@pytest.fixture
-def audio_dir_cbin(source_test_data_root):
-    return source_test_data_root.joinpath("audio_cbin_annot_notmat", "gy6or6", "032312")
+AUDIO_DIR_CBIN = SOURCE_TEST_DATA_ROOT.joinpath("audio_cbin_annot_notmat", "gy6or6", "032312")
 
 
 @pytest.fixture
-def audio_list_cbin(audio_dir_cbin):
-    return sorted(audio_dir_cbin.glob("*.cbin"))
+def audio_dir_cbin():
+    return AUDIO_DIR_CBIN
+
+
+AUDIO_LIST_CBIN = sorted(AUDIO_DIR_CBIN.glob("*.cbin"))
+
+
+@pytest.fixture
+def audio_list_cbin():
+    return AUDIO_LIST_CBIN
 
 
 @pytest.fixture
@@ -67,24 +75,36 @@ def audio_list_cbin_labels_not_in_labelset(
     return audio_list_labels_in_labelset
 
 
-@pytest.fixture
-def audio_dir_wav_birdsongrec(source_test_data_root):
-    return source_test_data_root.joinpath("audio_wav_annot_birdsongrec", "Bird0", "Wave")
+AUDIO_DIR_WAV_BIRDSONGREC = SOURCE_TEST_DATA_ROOT.joinpath("audio_wav_annot_birdsongrec", "Bird0", "Wave")
 
 
 @pytest.fixture
-def audio_list_wav_birdsongrec(audio_dir_wav_birdsongrec):
-    return sorted(audio_dir_wav_birdsongrec.glob("*.wav"))
+def audio_dir_wav_birdsongrec():
+    return AUDIO_DIR_WAV_BIRDSONGREC
+
+
+AUDIO_LIST_WAV_BIRDSONGREC = sorted(AUDIO_DIR_WAV_BIRDSONGREC.glob("*.wav"))
 
 
 @pytest.fixture
-def audio_dir_wav_textgrid(source_test_data_root):
-    return source_test_data_root.joinpath("audio_wav_annot_textgrid", "AGBk")
+def audio_list_wav_birdsongrec():
+    return AUDIO_LIST_WAV_BIRDSONGREC
+
+
+AUDIO_DIR_WAV_TEXTGRID = SOURCE_TEST_DATA_ROOT.joinpath("audio_wav_annot_textgrid", "AGBk")
 
 
 @pytest.fixture
-def audio_list_wav_textgrid(audio_dir_wav_textgrid):
-    return sorted(audio_dir_wav_textgrid.glob("*.WAV"))
+def audio_dir_wav_textgrid():
+    return AUDIO_DIR_WAV_TEXTGRID
+
+
+AUDIO_LIST_WAV_TEXTGRID = sorted(AUDIO_DIR_WAV_TEXTGRID.glob("*.WAV"))
+
+
+@pytest.fixture
+def audio_list_wav_textgrid():
+    return AUDIO_LIST_WAV_TEXTGRID
 
 
 @pytest.fixture

--- a/tests/fixtures/spect.py
+++ b/tests/fixtures/spect.py
@@ -3,19 +3,29 @@ import pytest
 
 import vak.files.spect
 
+from .test_data import GENERATED_TEST_DATA_ROOT, SOURCE_TEST_DATA_ROOT
+
+
+SPECT_DIR_MAT = SOURCE_TEST_DATA_ROOT.joinpath(
+    "spect_mat_annot_yarden", "llb3", "spect"
+)
+
 
 @pytest.fixture
-def spect_dir_mat(source_test_data_root):
-    return source_test_data_root.joinpath("spect_mat_annot_yarden", "llb3", "spect")
+def spect_dir_mat():
+    return SPECT_DIR_MAT
 
 
-@pytest.fixture
-def spect_dir_npz(generated_test_data_root):
-    return sorted(
-        generated_test_data_root.joinpath(
+SPECT_DIR_NPZ = sorted(
+        GENERATED_TEST_DATA_ROOT.joinpath(
             "prep", "train", "audio_cbin_annot_notmat", "teenytweetynet"
         ).glob("spectrograms_generated*")
     )[0]
+
+
+@pytest.fixture
+def spect_dir_npz():
+    return SPECT_DIR_NPZ
 
 
 @pytest.fixture
@@ -31,14 +41,20 @@ def specific_spect_dir(spect_dir_mat, spect_dir_npz):
     return _specific_spect_dir
 
 
-@pytest.fixture
-def spect_list_mat(spect_dir_mat):
-    return sorted(spect_dir_mat.glob("*.mat"))
+SPECT_LIST_MAT = sorted(SPECT_DIR_MAT.glob("*.mat"))
 
 
 @pytest.fixture
-def spect_list_npz(spect_dir_npz):
-    return sorted(spect_dir_npz.glob("*.spect.npz"))
+def spect_list_mat():
+    return SPECT_LIST_MAT
+
+
+SPECT_LIST_NPZ = sorted(SPECT_DIR_NPZ.glob("*.spect.npz"))
+
+
+@pytest.fixture
+def spect_list_npz():
+    return SPECT_LIST_NPZ
 
 
 @pytest.fixture

--- a/tests/test_files/test_files.py
+++ b/tests/test_files/test_files.py
@@ -1,14 +1,55 @@
 """tests for vak.files.files.files module"""
+import itertools
+
 import pytest
 
 import vak.files.files
 
+from ..fixtures.spect import (
+    SPECT_LIST_MAT,
+    SPECT_LIST_NPZ,
+)
 
-def test_find_fname():
-    fname = "llb3_0003_2018_04_23_14_18_54.wav.mat"
-    ext = "wav"
-    out = vak.files.files.find_fname(fname, ext)
-    assert out == "llb3_0003_2018_04_23_14_18_54.wav"
+SPECT_FNAME_LIST_MAT = [
+    spect_path.name for spect_path in SPECT_LIST_MAT
+] + [
+    # duplicate list but replace underscores in filenames with spaces to test handling spaces
+    spect_path.name.replace('_', ' ') for spect_path in SPECT_LIST_MAT
+]
+
+SPECT_FNAME_LIST_NPZ = [
+    spect_path.name for spect_path in SPECT_LIST_NPZ
+] + [
+    spect_path.name.replace('_', ' ') for spect_path in SPECT_LIST_NPZ
+]
+
+SPECT_FNAME_LIST_MAT_WITH_EXT = list(zip(
+    SPECT_FNAME_LIST_MAT,
+    itertools.repeat('.wav'),
+    itertools.repeat('.mat'),
+))
+
+SPECT_FNAME_LIST_NPZ_WITH_EXT = list(zip(
+    SPECT_FNAME_LIST_NPZ,
+    itertools.repeat('.cbin'),
+    itertools.repeat('.spect.npz'),
+))
+
+TEST_FIND_FNAME_PARAMETRIZE = SPECT_FNAME_LIST_MAT_WITH_EXT + SPECT_FNAME_LIST_NPZ_WITH_EXT
+
+
+@pytest.mark.parametrize(
+    'fname, find_ext, spect_ext',
+    TEST_FIND_FNAME_PARAMETRIZE
+)
+def test_find_fname(fname, find_ext, spect_ext):
+    """Test ``vak.files.files.find_fname`` works as expected."""
+    expected = fname.replace(spect_ext, '')
+
+    out = vak.files.files.find_fname(fname, find_ext)
+
+    assert fname.startswith(out)
+    assert out == expected
 
 
 def test_files_from_dir_with_mat(spect_dir_mat, spect_list_mat):

--- a/tests/test_files/test_spect.py
+++ b/tests/test_files/test_spect.py
@@ -1,5 +1,6 @@
 """tests for vak.files.spect module"""
-from pathlib import Path
+import itertools
+import pathlib
 
 import pytest
 
@@ -7,21 +8,72 @@ import vak.files
 from vak.constants import VALID_AUDIO_FORMATS
 
 
-@pytest.mark.parametrize(
-    "spect_format",
-    [
-        "mat",
-        "npz",
-    ],
+from ..fixtures.spect import (
+    SPECT_LIST_MAT,
+    SPECT_LIST_NPZ,
 )
-def test_find_audio_fname_with_mat(spect_format, specific_spect_list):
+
+
+SPECT_LIST_MAT = SPECT_LIST_MAT + [
+    # duplicate list but replace underscores in filenames with spaces to test handling spaces
+    spect_path.parent / spect_path.name.replace('_', ' ')
+    for spect_path in SPECT_LIST_MAT
+] + [
+    # duplicate list but replace underscores in entire path with spaces to test handling spaces
+    pathlib.Path(str(spect_path).replace('_', ' '))
+    for spect_path in SPECT_LIST_MAT
+]
+# test function with string paths not just pathlib.Path instances
+SPECT_LIST_MAT = SPECT_LIST_MAT + [str(path) for path in SPECT_LIST_MAT]
+
+SPECT_LIST_NPZ = SPECT_LIST_NPZ + [
+    # duplicate list but replace underscores in filenames with spaces to test handling spaces
+    spect_path.parent / spect_path.name.replace('_', ' ')
+    for spect_path in SPECT_LIST_NPZ
+] + [
+    # duplicate list but replace underscores in entire path with spaces to test handling spaces
+    pathlib.Path(str(spect_path).replace('_', ' '))
+    for spect_path in SPECT_LIST_NPZ
+]
+# test function with string paths not just pathlib.Path instances
+SPECT_LIST_NPZ = SPECT_LIST_NPZ + [str(path) for path in SPECT_LIST_NPZ]
+
+SPECT_LIST_MAT_WITH_EXT = list(zip(
+    SPECT_LIST_MAT,
+    itertools.repeat('.wav'),
+    itertools.repeat('.mat'),
+)) + list(zip(
+    SPECT_LIST_MAT,
+    # also test with case where we don't specify audio extension
+    itertools.repeat(None),
+    itertools.repeat('.mat'),
+))
+
+SPECT_LIST_NPZ_WITH_EXT = list(zip(
+    SPECT_LIST_NPZ,
+    itertools.repeat('.cbin'),
+    itertools.repeat('.spect.npz'),
+)) + list(zip(
+    SPECT_LIST_NPZ,
+    itertools.repeat(None),
+    itertools.repeat('.spect.npz'),
+))
+
+TEST_FIND_AUDIO_FNAME_PARAMETRIZE = SPECT_LIST_MAT_WITH_EXT + SPECT_LIST_NPZ_WITH_EXT
+
+
+@pytest.mark.parametrize(
+    "spect_path, audio_ext, spect_ext",
+    TEST_FIND_AUDIO_FNAME_PARAMETRIZE
+)
+def test_find_audio_fname_with_mat(spect_path, audio_ext, spect_ext):
     """test ```vak.files.spect.find_audio_fname`` works when we give it a list of """
-    spect_list = specific_spect_list(spect_format)
-    audio_fnames = [
-        vak.files.spect.find_audio_fname(spect_path) for spect_path in spect_list
-    ]
-    for spect_path, audio_fname in zip(spect_list, audio_fnames):
-        # make sure we gout out a filename that was actually in spect_path
-        assert spect_path.name.startswith(audio_fname)
-        # make sure it's some valid audio format
-        assert Path(audio_fname).suffix.replace(".", "") in VALID_AUDIO_FORMATS
+    expected = pathlib.Path(spect_path).name.replace(spect_ext, '')
+
+    out = vak.files.spect.find_audio_fname(spect_path, audio_ext)
+
+    # make sure we gout out a filename that was actually in spect_path
+    assert pathlib.Path(spect_path).name.startswith(out)
+    # make sure it's some valid audio format
+    assert pathlib.Path(out).suffix.replace(".", "") in VALID_AUDIO_FORMATS
+    assert out == expected


### PR DESCRIPTION
Makes two functions in `files` handle paths/filenames with spaces in them: `vak.files.files.find_fname` and `vak.files.spect.find_audio_fname`