### PR TITLE
Add options to prep for how `vak.io.audio.to_spect` calls `dask.bag`

### DIFF
--- a/src/vak/cli/prep.py
+++ b/src/vak/cli/prep.py
@@ -140,6 +140,7 @@ def prep(toml_path):
         annot_format=cfg.prep.annot_format,
         annot_file=cfg.prep.annot_file,
         labelset=cfg.prep.labelset,
+        audio_dask_bag_kwargs=cfg.prep.audio_dask_bag_kwargs,
         output_dir=cfg.prep.output_dir,
         train_dur=cfg.prep.train_dur,
         val_dur=cfg.prep.val_dur,

--- a/src/vak/config/valid.toml
+++ b/src/vak/config/valid.toml
@@ -14,6 +14,7 @@ spect_output_dir = './tests/test_data/generated/audio_cbin_annot_notmat'
 annot_format = 'notmat'
 annot_file = './some/annot/file'
 labelset = 'iabcdefghjk'
+audio_dask_bag_kwargs = { npartitions = 20}
 train_dur = 50
 val_dur = 15
 test_dur = 30

--- a/src/vak/core/prep.py
+++ b/src/vak/core/prep.py
@@ -32,6 +32,7 @@ def prep(
     annot_format=None,
     annot_file=None,
     labelset=None,
+    audio_dask_bag_kwargs=None,
     train_dur=None,
     val_dur=None,
     test_dur=None,
@@ -99,6 +100,14 @@ def prep(
         contains labels not found in ``labelset``.
         ``labelset`` is converted to a Python ``set`` using ``vak.converters.labelset_to_set``.
         See help for that function for details on how to specify labelset.
+    audio_dask_bag_kwargs : dict
+        Keyword arguments used when calling ``dask.bag.from_sequence``
+        inside ``vak.io.audio``, where it is used to parallelize
+        the conversion of audio files into spectrograms.
+        Option should be specified in config.toml file as an inline table,
+        e.g., ``audio_dask_bag_kwargs = { npartitions = 20 }``.
+        Allows for finer-grained control
+        when needed to process files of different sizes.
     train_dur : float
         total duration of training set, in seconds. When creating a learning curve,
         training subsets of shorter duration will be drawn from this set. Default is None.
@@ -222,8 +231,9 @@ def prep(
         annot_file=annot_file,
         audio_format=audio_format,
         spect_format=spect_format,
-        spect_output_dir=spect_output_dir,
         spect_params=spect_params,
+        spect_output_dir=spect_output_dir,
+        audio_dask_bag_kwargs=audio_dask_bag_kwargs,
     )
 
     if vak_df.empty:

--- a/src/vak/io/dataframe.py
+++ b/src/vak/io/dataframe.py
@@ -23,6 +23,7 @@ def from_files(
     spect_format=None,
     spect_params=None,
     spect_output_dir=None,
+    audio_dask_bag_kwargs=None,
 ):
     """create a pandas DataFrame representing a dataset for machine learning
     from a set of files in a directory
@@ -71,6 +72,14 @@ def from_files(
         Default is None, in which case it defaults to ``data_dir``.
         A new directory will be created in ``spect_output_dir`` with
         the name 'spectrograms_generated_{time stamp}'.
+    audio_dask_bag_kwargs : dict
+        Keyword arguments used when calling ``dask.bag.from_sequence``
+        inside ``vak.io.audio``, where it is used to parallelize
+        the conversion of audio files into spectrograms.
+        Option should be specified in config.toml file as an inline table,
+        e.g., ``audio_dask_bag_kwargs = { npartitions = 20 }``.
+        Allows for finer-grained control
+        when needed to process files of different sizes.
 
     Returns
     -------
@@ -138,6 +147,7 @@ def from_files(
             audio_files=audio_files,
             annot_list=annot_list,
             labelset=labelset,
+            dask_bag_kwargs=audio_dask_bag_kwargs,
         )
         spect_format = "npz"
     else:  # if audio format is None

--- a/tests/test_io/test_audio.py
+++ b/tests/test_io/test_audio.py
@@ -392,3 +392,44 @@ def test_both_annot_list_and_audio_annot_map_raises(
             audio_annot_map=audio_annot_map,
             labelset=labelset_notmat,
         )
+
+
+@pytest.mark.parametrize(
+    'dask_bag_kwargs',
+    [
+        None,
+        dict(npartitions=20),
+    ]
+)
+def test_dask_bag_kwargs(
+    dask_bag_kwargs,
+    default_spect_params,
+    tmp_path,
+    audio_dir_cbin,
+    annot_list_notmat,
+    labelset_notmat,
+    audio_list_cbin_all_labels_in_labelset,
+    audio_list_cbin_labels_not_in_labelset,
+
+):
+    """Test the ``dask_bag_kwargs`` parameter.
+
+    This is a smoke test, it does not carefully test different parameters.
+    It's the test above ``test_to_spect_audio_dir_annot_cbin_with_labelset``
+    with the parameter ``dask_bag_kwargs`` added."""
+    spect_files = vak.io.audio.to_spect(
+        audio_format="cbin",
+        spect_params=default_spect_params,
+        output_dir=tmp_path,
+        audio_dir=audio_dir_cbin,
+        audio_files=None,
+        annot_list=annot_list_notmat,
+        audio_annot_map=None,
+        labelset=labelset_notmat,
+        dask_bag_kwargs=dask_bag_kwargs
+    )
+    assert expected_spect_files_returned(
+        spect_files,
+        audio_list_cbin_all_labels_in_labelset,
+        audio_list_cbin_labels_not_in_labelset,
+    )


### PR DESCRIPTION
Fixes #580 