### PR TITLE
BUG: Fix post_tfm in version 1.0

### DIFF
--- a/src/vak/config/eval.py
+++ b/src/vak/config/eval.py
@@ -92,7 +92,7 @@ class EvalConfig:
         when transforming labeled timebins to segments,
         the default behavior.
         The transform used is
-        ``vak.transforms.labeled_timebins.ToSegmentsWithPostProcessing`.
+        ``vak.transforms.labeled_timebins.PostProcess`.
         Valid keyword argument names are 'majority_vote'
         and 'min_segment_dur', and should be appropriate
         values for those arguments: Boolean for ``majority_vote``,

--- a/src/vak/core/eval.py
+++ b/src/vak/core/eval.py
@@ -79,7 +79,7 @@ def eval(
         If None, then no additional clean-up is applied
         when transforming labeled timebins to segments,
         the default behavior. The transform used is
-        ``vak.transforms.labeled_timebins.ToSegmentsWithPostProcessing`.
+        ``vak.transforms.labeled_timebins.PostProcess`.
         Valid keyword argument names are 'majority_vote'
         and 'min_segment_dur', and should be appropriate
         values for those arguments: Boolean for ``majority_vote``,
@@ -193,6 +193,7 @@ def eval(
         num_classes=len(labelmap),
         input_shape=input_shape,
         labelmap=labelmap,
+        post_tfm=post_tfm,
     )
 
     logger.info(f"running evaluation for model: {model_name}")

--- a/src/vak/models/get.py
+++ b/src/vak/models/get.py
@@ -1,6 +1,7 @@
 """Function that gets an instance of a model,
 given its name and a configuration as a dict."""
 from __future__ import annotations
+from typing import Callable
 
 from ._api import MODEL_NAMES
 
@@ -10,7 +11,8 @@ def get(name: str,
         # TODO: move num_classes / input_shape into model configs
         num_classes: int,
         input_shape: tuple[int, int, int],
-        labelmap: dict):
+        labelmap: dict,
+        post_tfm: Callable | None = None):
     """Get a model instance, given its name and
     a configuration as a ``dict``.
 
@@ -34,8 +36,7 @@ def get(name: str,
         ``vak.transforms.labeled_timebins.ToLabels`` (that does not
         apply any post-processing clean-ups).
         To be valid, ``post_tfm`` must be either an instance of
-        ``vak.transforms.labeled_timebins.ToLabels`` or
-        ``vak.transforms.labeled_timebins.ToLabelsWithPostprocessing``.
+        ``vak.transforms.labeled_timebins.PostProcess``.
 
     Returns
     -------
@@ -59,6 +60,6 @@ def get(name: str,
             f"Invalid model name: '{name}'.\nValid model names are: {MODEL_NAMES}"
         ) from e
 
-    model = model_class.from_config(config=config, labelmap=labelmap)
+    model = model_class.from_config(config=config, labelmap=labelmap, post_tfm=post_tfm)
 
     return model


### PR DESCRIPTION
After rebasing version-1.0 branch on top of main where we added the ability to run eval with and without post-processing (in #621), we lost that functionality. That's because the post-processing transform is not passed in to the new model abstraction / backend, even though everything is in place to do so (parameters to functions, etc.)

This PR fixes that.

squash commits:
- Add post_tfm parameter to models.get
  - fix docstring to say PostProcess
  - pass post_tfm into Model.from_config
- Fix post_tfm_kwargs definition in EvalConfig docstring in src/vak/config/eval.py to say PostProcess transform
- In core/eval.py, fix post_tfm_kwargs docstring and actually pass post_tfm into models.get
- Fix validation_step method of WindowedFrameClassificationModel to match what engine.Model._eval does with post_tfm in version 0.x