### PR TITLE
BUG: Fix usage of crowsetta 5.0

### DIFF
--- a/src/vak/annotation.py
+++ b/src/vak/annotation.py
@@ -155,7 +155,7 @@ def files_from_dir(annot_dir, annot_format):
     elif isinstance(format_class.ext, tuple):
         # then we actually have to determine whether there's any files for either format
         for ext_to_test in format_class.ext:
-            if len(pathlib.Path(annot_dir).glob(f'*{ext_to_test}')) > 0:
+            if len(sorted(pathlib.Path(annot_dir).glob(f'*{ext_to_test}'))) > 0:
                 ext = ext_to_test
     if ext is None:
         raise ValueError(


### PR DESCRIPTION
This is a bugfix for #657 

I found another place where we need to handle the edge case of annotation formats that have more than one valid extension (specifically, 'simple-seq') in the function `vak.annotation.files_from_dir`. I handle it basically the same way we did for `vak.annotation.from_df`, except that I need to glob to figure out if there's any files with either extension, which kind of defeats the purpose of calling `vak.files.from_dir`. But this fixes the issue with 'simple-seq' for now.