### PR TITLE
ENH: Determine network kwargs dynamically in `vak.models.get`

### DIFF
--- a/src/vak/models/get.py
+++ b/src/vak/models/get.py
@@ -1,6 +1,7 @@
 """Function that gets an instance of a model,
 given its name and a configuration as a dict."""
 from __future__ import annotations
+import inspect
 from typing import Callable
 
 from . import registry
@@ -53,7 +54,12 @@ def get(name: str,
         ) from e
 
     # still need to special case model logic here
-    if name in ('TweetyNet', 'TeenyTweetyNet', 'ED_TCN'):
+    net_init_params = list(
+        inspect.signature(
+            model_class.definition.network.__init__
+        ).parameters.keys()
+    )
+    if ('num_input_channels' in net_init_params) and ('num_freqbins' in net_init_params):
         num_input_channels = input_shape[-3]
         num_freqbins = input_shape[-2]
         config["network"].update(

--- a/src/vak/models/get.py
+++ b/src/vak/models/get.py
@@ -68,9 +68,8 @@ def get(name: str,
             num_freqbins=num_freqbins
         )
     else:
-        model_names = list(all_models_dict.keys())
         raise ValueError(
-            f"Invalid model name: '{name}'.\nValid model names are: {model_names}"
+            f"Unable to determine network init arguments for model: {name}"
         )
 
     model = model_class.from_config(config=config, labelmap=labelmap, post_tfm=post_tfm)


### PR DESCRIPTION
This pull request uses `inspect.signature` to determine whether a model's network has `num_input_channels` and `num_freqbins` parameters, and then gets the corresponding values from the dataset's input shape to add to the keyword arguments used when instantiating the model.

This approach is fragile but at least makes it possible to use a model that is not built in, as long as that model's network has these keyword arguments.