### PR TITLE
BUG/CLN: Add/fix log statements in FrameClassificationModel

### DIFF
--- a/src/vak/models/frame_classification_model.py
+++ b/src/vak/models/frame_classification_model.py
@@ -192,6 +192,7 @@ class FrameClassificationModel(base.Model):
         x, y = batch[0], batch[1]
         out = self.network(x)
         loss = self.loss(out, y)
+        self.log(f'train_loss', loss)
         return loss
 
     def validation_step(self, batch: tuple, batch_idx: int):
@@ -264,19 +265,19 @@ class FrameClassificationModel(base.Model):
         # TODO: figure out smarter way to do this
         for metric_name, metric_callable in self.metrics.items():
             if metric_name == "loss":
-                self.log(f'val_{metric_name}', metric_callable(out, y), batch_size=1)
+                self.log(f'val_{metric_name}', metric_callable(out, y), batch_size=1, on_step=True)
             elif metric_name == "acc":
                 self.log(f'val_{metric_name}', metric_callable(y_pred, y), batch_size=1)
                 if self.post_tfm:
                     self.log(f'val_{metric_name}_tfm',
                              metric_callable(y_pred_tfm, y),
-                             batch_size=1)
+                             batch_size=1, on_step=True)
             elif metric_name == "levenshtein" or metric_name == "segment_error_rate":
                 self.log(f'val_{metric_name}', metric_callable(y_pred_labels, y_labels), batch_size=1)
                 if self.post_tfm:
                     self.log(f'val_{metric_name}_tfm',
                              metric_callable(y_pred_tfm_labels, y_labels),
-                             batch_size=1)
+                             batch_size=1, on_step=True)
 
     def predict_step(self, batch: tuple, batch_idx: int):
         """Perform one prediction step.


### PR DESCRIPTION
Inspecting tensorboard log files generated by version 1.0 revealed that we were no longer logging metrics at every validation step and we were not logging training loss at all.

This PR:
- [x] adds a log statement in the training step for the FrameClassification model
- [x] sets `on_step=True` inside log statements in the validation step for the FrameClassification model, so that we do log metrics at every validation step, instead of just on epoch end (which we didn't even reach in some cases when a model finishes training before the first epoch) 