### PR TITLE
BUG: Make distance metrics return tensors, fix #700 #701

### DIFF
--- a/src/vak/metrics/distance/functional.py
+++ b/src/vak/metrics/distance/functional.py
@@ -1,4 +1,5 @@
 import numpy as np
+import torch
 
 
 def levenshtein(source, target):
@@ -65,7 +66,7 @@ def levenshtein(source, target):
 
         d0, d1 = d1, d0
 
-    return d0[-1]
+    return torch.tensor(d0[-1], dtype=torch.int32)
 
 
 def segment_error_rate(y_pred, y_true):
@@ -95,4 +96,5 @@ def segment_error_rate(y_pred, y_true):
             "segment error rate is undefined when length of y_true is zero"
         )
 
-    return levenshtein(y_pred, y_true) / len(y_true)
+    rate = levenshtein(y_pred, y_true) / len(y_true)
+    return torch.tensor(rate, dtype=torch.float32)


### PR DESCRIPTION
Makes functions in `vak.transforms.distance.functional` return tensors so we don't cause errors when lightning tries to convert from numpy to tensors to log.

Letting lightning do the conversion kind of works, but it can cause a fatal error
for someone using an Apple M1 with 'mps' as the accelerator, see https://forum.vocalpy.org/t/vak-tweetynet-with-an-apple-m1-max/78/4?u=nicholdav

I don't find any explicit statement in either the Lightning or Torchmetrics docs that metrics should always be tensors, and that this guarantees there won't be weird issues (right now we get a warning on start-up that all logged scalars should be float32, but I would expect one should be able to log integers too?).
But from various issues I read, it seems like that should be the case, https://github.com/Lightning-AI/lightning/issues/2143 and I notice that torchmetrics classes tend to do things like convert to a float tensor