### PR TITLE
DOC: Add eval to autoannotate, fix #460

### DIFF
--- a/doc/get_started/autoannotate.md
+++ b/doc/get_started/autoannotate.md
@@ -323,6 +323,39 @@ validation set improves, named `max-val-acc-checkpoint.pt`.
 If you were to use the `max-val-acc-checkpoint.pt` then the path would end
 with `TweetyNet/checkpoints/max-val-acc-checkpoint.pt`.
 
+
+```toml
+checkpoint_path = "/home/users/You/Data/vak_tutorial_data/vak_output/results_{timestamp}/TweetyNet/checkpoints/max-val-acc-checkpoint.pt"
+```
+
+In some cases, a `max-val-acc-checkpoint.pt` may not get saved;
+this depends on the options for training and non-deterministic factors like
+the randomly initialized weights of the network.
+For the purposes of completing this tutorial, using either checkpoint is fine.
+
+The second path you want is the one to the file containing the `labelmap`.
+The `labelmap` is a Python
+dictionary that maps the labels from your annotation to a set of consecutive integers, which
+are the outputs the neural network learns to predict during training. It is saved in a `.json`
+file in the root `results_{timestamp}` directory.
+
+```toml
+labelmap_path = "/home/users/You/Data/vak_tutorial_data/vak_output/results_{timestamp}/labelmap.json"
+```
+
+The third and last path you need is the path to the file containing a saved `spect_scaler`.
+The `SpectScaler` represents a transform
+applied to the data that helps when training the neural network.
+You need to apply the same transform to the new
+data for which you are predicting labels--otherwise the accuracy will be impaired.
+Note that the file does not have an extension. (In case you are curious,
+it's a pickled Python object saved by the `joblib` library.)
+This file will also be found in the root `results_{timestamp}` directory.
+
+```toml
+spect_scaler = "/home/users/You/Data/vak_tutorial_data/vak_output/results_{timestamp}/SpectScaler"
+```
+
 The last path you need is actually in the TOML file that we used 
 to train the neural network: `dataset_path`.
 You should copy that `dataset_path` option exactly as it is 
@@ -395,7 +428,10 @@ and then add the path to that file as the option `csv_path` in the `[PREDICT]` s
 Finally you will use the trained network to predict annotations.
 This is the part that requires you to find paths to files saved by `vak`.
 
-There's three you need. All three will be in the `results` directory
+There's three you need. These are the exact same paths we used above 
+in the configuration file for evaluation, so you can copy them from that file.
+We explain them again here for completeness.
+All three paths will be in the `results` directory
 created by `vak` when you ran `train`. If you replaced the dummy path in
 capital letters in the config file, but kept the rest of the path,
 then this will be a location with a name like
@@ -433,7 +469,7 @@ are the outputs the neural network learns to predict during training. It is save
 file in the root `results_{timestamp}` directory.
 
 ```toml
-spect_scaler = "/home/users/You/Data/vak_tutorial_data/vak_output/results_{timestamp}/labelmap.json"
+labelmap_path = "/home/users/You/Data/vak_tutorial_data/vak_output/results_{timestamp}/labelmap.json"
 ```
 
 The third and last path you need is the path to the file containing a saved `spect_scaler`.

--- a/doc/get_started/autoannotate.md
+++ b/doc/get_started/autoannotate.md
@@ -73,18 +73,20 @@ Before going through this tutorial, you'll need to:
      :::
 
 4. Download the corresponding configuration files (click to download):
-   {download}`gy6or6_train.toml <../toml/gy6or6_train.toml>`
+   {download}`gy6or6_train.toml <../toml/gy6or6_train.toml>`,
+   {download}`gy6or6_eval.toml <../toml/gy6or6_eval.toml>, 
    and {download}`gy6or6_predict.toml <../toml/gy6or6_predict.toml>`
 
 ## Overview
 
-There are four steps to using `vak` to automate annotating vocalizations
+There are five steps to using `vak` to automate annotating vocalizations
 
 1. {ref}`prepare a training dataset <prepare-training-dataset>`, from
    a small annotated dataset of vocalizations
-2. {ref}`train a neural <train-neural-network>` network with that dataset
-3. {ref}`prepare a prediction dataset <prepare-prediction-dataset>` of unannotated data
-4. {ref}`use the trained network <use-trained-network>` to predict annotations for the prediction dataset
+2. {ref}`train a neural network <train-neural-network>` with that dataset
+3. {ref}`evaluate the trained model <evaluate-model>` with a held-out dataset
+4. {ref}`prepare a prediction dataset <prepare-prediction-dataset>` of unannotated data
+5. {ref}`use the trained network <use-trained-network>` to predict annotations for the prediction dataset
 
 Before doing that, you'll need to know a little bit about working with the shell,
 since that's the main way to work with `vak` without writing any code.
@@ -158,7 +160,7 @@ of modifying a configuration file and then using it to `prep` a dataset.
 
 (prepare-training-dataset)=
 
-## 1. preparing a training dataset
+## 1. Preparing a training dataset
 
 To train a neural network how to predict annotations,
 you'll need to tell `vak` where your dataset is.
@@ -172,7 +174,7 @@ to help you pick them out, like so:
 
 ```{literalinclude} ../toml/gy6or6_train.toml
 :language: toml
-:lines: 1-3
+:lines: 1-10
 ```
 
 Change the part of the path in capital letters to the actual location
@@ -180,6 +182,9 @@ on your computer:
 
 ```toml
 [PREP]
+dataset_type = "frame classification"
+input_type = "spect"
+# we change the next line
 data_dir = "/home/users/You/Data/vak_tutorial_data/032212"
 ```
 
@@ -234,14 +239,13 @@ When that time comes, please see the how-to page:
 For now, let's move on to training a neural network with this dataset.
 
 (train-neural-network)=
-## 2. training a neural network
+## 2. Training a neural network model
 
 Now that you've prepared the dataset, you can train a neural network with it.
 In this example we will train `TweetyNet`,
 a neural network architecture that annotates vocalizations
 (see: <https://github.com/yardencsGitHub/tweetynet> ).
-Please make sure you have installed it following the steps in
-{ref}`install-tweetynet` in {ref}`installation`.
+As of version 1.0, TweetyNet is built into vak.
 
 Before we start training, there is one option you have to change in the `[TRAIN]` section
 of the `config.toml` file, `root_results_dir`,
@@ -268,7 +272,7 @@ to train models for annotation on a CPU,
 with training times ranging from a couple hours to overnight.
 :::
 
-To train a neural network, you simply run:
+To train a neural network, you run this command in the shell:
 
 ```shell
 vak train gy6o6_train.toml
@@ -284,9 +288,71 @@ You can also just stop after one epoch if you want to go through the rest of the
 options also specify that `vak` should save a "checkpoint" every epoch, and we need to load our trained network
 from that checkpoint later when we predict annotations for new data.
 
+(evaluate-trained-model)=
+
+## 3. Evaluating a trained model
+
 (prepare-prediction-dataset)=
 
-## 3. preparing a prediction dataset
+An important step when using neural network models is to evaluate the model's performance 
+on a held-out dataset that has never been used during training, often called the "test" set.
+
+Here we show you how to evaluate the model we just trained.
+
+This part requires you to find paths to files saved by `vak`.
+
+There's four you need. Three of them will be in the `results` directory
+created by `vak` when you ran `train`. If you replaced the dummy path in
+capital letters in the config file, but kept the rest of the path,
+then this will be a location with a name like
+`/PATH/TO/DATA/vak/train/results/results_{timestamp}`,
+where `PATH/TO/DATA/` will be replaced with a path on your machine,
+and where `{timestamp}` is an actual time in the format `yymmdd_HHMMSS`
+(year-month-day hour-minute-second).
+
+The first path you need is the `checkpoint_path`. This is the full
+path, including filename, to the file that contains the weights (also known as parameters)
+of the trained neural network, saved by `vak`.
+There will be a directory inside the `results_{timestamp}` directory
+with the name of the trained model, `TweetyNet`,
+and inside that sits a `checkpoints` directory that has the actual file you want.
+Typically there will be two checkpoint files, one named just `checkpoint.pt` that is
+saved intermittently as a backup,
+and another that is saved only when accuracy on the
+validation set improves, named `max-val-acc-checkpoint.pt`.
+If you were to use the `max-val-acc-checkpoint.pt` then the path would end
+with `TweetyNet/checkpoints/max-val-acc-checkpoint.pt`.
+
+The last path you need is actually in the TOML file that we used 
+to train the neural network: `dataset_path`.
+You should copy that `dataset_path` option exactly as it is 
+and then paste it at the bottom of the `[EVAL]` table 
+in the configuration file for evaluation.
+We do this instead of preparing another dataset, 
+because we already created a test split when we ran 
+`vak prep` with the training configuration.
+This is a good practice, because it helps ensure 
+that we do not mix the training data with the test data;
+`vak` makes sure that the data from the `data_dir` option 
+is placed in two separate splits, the train and test splits.
+
+Once you have prepared the configuration file as described, 
+you can run the following in the terminal:
+
+```shell
+vak eval gy6o6_eval.toml
+```
+
+You will see output to the console as the network is evaluated. 
+Notice that for this model we evaluate it *with* and *without* 
+post-processing transforms that clean up the predictions 
+of the model.
+The parameters of the post-processing transform are specified 
+with the `post_tfm_kwargs` option in the configuration file.
+You may find this helpful to understand factors affecting 
+the performance of your own model.
+
+## 4. Preparing a prediction dataset
 
 Next you'll prepare a dataset for prediction. The dataset we downloaded has annotation files with it,
 but for the sake of this tutorial we'll pretend that they're not annotated, and we instead want to
@@ -324,7 +390,7 @@ and then add the path to that file as the option `csv_path` in the `[PREDICT]` s
 
 (use-trained-network)=
 
-## 4. using a trained network to predict annotations
+## 5. Using a trained network to predict annotations
 
 Finally you will use the trained network to predict annotations.
 This is the part that requires you to find paths to files saved by `vak`.
@@ -410,5 +476,6 @@ predicted by the trained neural network.
 vak predict gy6or6_predict.toml
 ```
 
-That's it! With those four simple steps you can train neural networks and then use the
+That's it! With those five simple steps you can train neural networks,
+evaluate the train models, and then use the
 trained networks to predict annotations for vocalizations.

--- a/doc/index.md
+++ b/doc/index.md
@@ -20,10 +20,11 @@ please see this talk from the SciPy 2023 conference,
 and the associated Proceedings paper 
 [here](https://conference.scipy.org/proceedings/scipy2023/pdfs/david_nicholson.pdf).
 
-```{iframe} https://www.youtube.com/embed/tpL0m5UwpZM?si=YSoCpS_Upa7h9hyw
-:width: 100%
-SciPy 2023 talk on vak
-```
+<p align="center">
+<a href="https://www.youtube.com/watch?v=tpL0m5UwpZM" target="_blank">
+ <img src="https://img.youtube.com/vi/tpL0m5UwpZM/mqdefault.jpg" alt="Thumbnail of SciPy 2023 talk on vak" width="400" border="10" />
+</a>
+</p>
 
 Currently, the main use is automated **annotation** of animal vocalizations.
 By **annotation**, we mean something like this example of annotated birdsong:

--- a/doc/toml/gy6or6_eval.toml
+++ b/doc/toml/gy6or6_eval.toml
@@ -1,0 +1,72 @@
+[PREP]
+# dataset_type: corresponds to the model family such as "frame classification" or "parametric umap"
+dataset_type = "frame classification"
+# input_type: input to model, either audio ("audio") or spectrogram ("spect")
+input_type = "spect"
+# data_dir: directory with data to use when preparing dataset
+data_dir = "/PATH/TO/DATA/032212"
+# output_dir: directory where dataset will be created (as a sub-directory within output_dir)
+output_dir = "/PATH/TO/DATA/vak/prep/train"
+# audio_format: format of audio, either wav or cbin
+audio_format = "wav"
+# annot_format: format of annotations
+annot_format = "simple-seq"
+# labelset: string or array with unique set of labels used in annotations
+labelset = "iabcdefghjk"
+# train_dur: duration of training split in dataset, in seconds
+train_dur = 50
+# val_dur: duration of validation split in dataset, in seconds
+val_dur = 15
+
+# SPECT_PARAMS: parameters for computing spectrograms
+[SPECT_PARAMS]
+# fft_size: size of window used for Fast Fourier Transform, in number of samples
+fft_size = 512
+# step_size: size of step to take when computing spectra with FFT for spectrogram
+# also known as hop size
+step_size = 64
+
+# EVAL: options for evaluating a trained model
+[EVAL]
+model = "TweetyNet"
+# checkpoint_path: path to saved model checkpoint
+checkpoint_path = "~/Documents/repos/coding/birdsong/TweetyNet/results/BFSongRepository/gy6or6/results_200620_165308/TweetyNet/checkpoints/max-val-acc-checkpoint.pt"
+# labelmap_path: path to file that maps from outputs of model (integers) to text labels in annotations;
+# this is used when generating predictions
+labelmap_path = "~/Documents/repos/coding/birdsong/TweetyNet/results/BFSongRepository/gy6or6/results_200620_165308/labelmap.json"
+# spect_scaler_path: path to file containing SpectScaler that was fit to training set
+# We want to transform the data we predict on in the exact same way
+spect_scaler_path = "~/Documents/repos/coding/birdsong/TweetyNet/results/BFSongRepository/gy6or6/results_200620_165308/StandardizeSpect"
+# batch_size
+# for predictions with a frame classification model, this should always be 1
+# and will be ignored if it's not
+batch_size = 11
+# num_workers: number of workers to use when loading data with multiprocessing
+num_workers = 16
+# device: name of device to run model on, one of "cuda", "cpu"
+device = "cuda"
+# output_dir: directory where output should be saved, as a sub-directory within `output_dir`
+output_dir = "./tests/data_for_tests/generated/results/eval/audio_cbin_annot_notmat/TweetyNet"
+
+# EVAL.post_tfm_kwargs: options for post-processing
+[EVAL.post_tfm_kwargs]
+# both these transforms require that there is an "unlabeled" label,
+# and they will only be applied to segments that are bordered on both sides
+# by the "unlabeled" label.
+# Such a label class is added by default by vak.
+# majority_vote: post-processing transformation that takes majority vote within segments that
+# do not have the 'unlabeled' class label. Only applied if `majority_vote` is `true`
+# (default is false).
+majority_vote = true
+# min_segment_dur: post-processing transformation removes any segments
+# with a duration shorter than `min_segment_dur` that do not have the 'unlabeled' class.
+# Only applied if this option is specified.
+min_segment_dur = 0.02
+
+# transform_params: parameters used when transforming data
+# for a frame classification model, we use FrameDataset with the eval_item_transform,
+# that reshapes batches into consecutive adjacent windows with a specific `window_size`
+[EVAL.transform_params]
+window_size = 88
+
+# Note we do not specify any options for the network, and just use the defaults

--- a/doc/toml/gy6or6_eval.toml
+++ b/doc/toml/gy6or6_eval.toml
@@ -26,17 +26,17 @@ fft_size = 512
 # also known as hop size
 step_size = 64
 
-# EVAL: options for evaluating a trained model
+# EVAL: options for evaluating a trained model. This is done using the "test" split.
 [EVAL]
 model = "TweetyNet"
 # checkpoint_path: path to saved model checkpoint
-checkpoint_path = "~/Documents/repos/coding/birdsong/TweetyNet/results/BFSongRepository/gy6or6/results_200620_165308/TweetyNet/checkpoints/max-val-acc-checkpoint.pt"
+checkpoint_path = "/PATH/TO/DATA/vak/results/train/RESULTS_TIMESTAMP/TweetyNet/checkpoints/max-val-acc-checkpoint.pt"
 # labelmap_path: path to file that maps from outputs of model (integers) to text labels in annotations;
 # this is used when generating predictions
-labelmap_path = "~/Documents/repos/coding/birdsong/TweetyNet/results/BFSongRepository/gy6or6/results_200620_165308/labelmap.json"
+labelmap_path = "/PATH/TO/DATA/vak/results/train/RESULTS_TIMESTAMP/labelmap.json"
 # spect_scaler_path: path to file containing SpectScaler that was fit to training set
 # We want to transform the data we predict on in the exact same way
-spect_scaler_path = "~/Documents/repos/coding/birdsong/TweetyNet/results/BFSongRepository/gy6or6/results_200620_165308/StandardizeSpect"
+spect_scaler_path = "/PATH/TO/DATA/vak/results/train/RESULTS_TIMESTAMP/StandardizeSpect"
 # batch_size
 # for predictions with a frame classification model, this should always be 1
 # and will be ignored if it's not
@@ -46,7 +46,9 @@ num_workers = 16
 # device: name of device to run model on, one of "cuda", "cpu"
 device = "cuda"
 # output_dir: directory where output should be saved, as a sub-directory within `output_dir`
-output_dir = "./tests/data_for_tests/generated/results/eval/audio_cbin_annot_notmat/TweetyNet"
+output_dir = "/PATH/TO/DATA/vak/results/eval"
+# dataset_path : path to dataset created by prep
+# ADD THE dataset_path OPTION FROM THE TRAIN FILE HERE (we already created a test split when we ran `vak prep` with that config)
 
 # EVAL.post_tfm_kwargs: options for post-processing
 [EVAL.post_tfm_kwargs]

--- a/doc/toml/gy6or6_predict.toml
+++ b/doc/toml/gy6or6_predict.toml
@@ -26,11 +26,11 @@ step_size = 64
 [PREDICT]
 # model: the string name of the model. must be a name within `vak.models` or added e.g. with `vak.model.decorators.model`
 model = "TweetyNet"
+# checkpoint_path: path to saved model checkpoint
+checkpoint_path = "/PATH/TO/DATA/vak/train/RESULTS_TIMESTAMP/TweetyNet/checkpoints/max-val-acc-checkpoint.pt"
 # labelmap_path: path to file that maps from outputs of model (integers) to text labels in annotations;
 # this is used when generating predictions
 labelmap_path = "/PATH/TO/DATA/vak/train/RESULTS_TIMESTAMP/labelmap.json"
-# checkpoint_path: path to checkpoint
-checkpoint_path = "/PATH/TO/DATA/vak/train/RESULTS_TIMESTAMP/TweetyNet/checkpoints/max-val-acc-checkpoint.pt"
 # spect_scaler_path: path to file containing SpectScaler that was fit to training set
 # We want to transform the data we predict on in the exact same way
 spect_scaler_path = "/PATH/TO/DATA/vak/train/RESULTS_TIMESTAMP/StandardizeSpect"
@@ -46,6 +46,11 @@ device = "cuda"
 output_dir = "/PATH/TO/DATA/vak/prep/predict"
 # annot_csv_filename
 annot_csv_filename = "gy6or6.032312.annot.csv"
+# The next two options are for post-processing transforms.
+# Both these transforms require that there is an "unlabeled" label,
+# and they will only be applied to segments that are bordered on both sides
+# by the "unlabeled" label.
+# Such a label class is added by default by vak.
 # majority_vote: post-processing transformation that takes majority vote within segments that
 # do not have the 'unlabeled' class label. Only applied if `majority_vote` is `true`
 # (default is false).
@@ -61,4 +66,4 @@ min_segment_dur = 0.01
 [PREDICT.transform_params]
 window_size = 176
 
-# NOte we do not specify any options for the network, and just use the defaults
+# Note we do not specify any options for the network, and just use the defaults

--- a/doc/toml/gy6or6_predict.toml
+++ b/doc/toml/gy6or6_predict.toml
@@ -43,7 +43,7 @@ num_workers = 4
 # device: name of device to run model on, one of "cuda", "cpu"
 device = "cuda"
 # output_dir: directory where output should be saved, as a sub-directory within `output_dir`
-output_dir = "/PATH/TO/DATA/vak/prep/predict"
+output_dir = "/PATH/TO/DATA/vak/results/predict"
 # annot_csv_filename
 annot_csv_filename = "gy6or6.032312.annot.csv"
 # The next two options are for post-processing transforms.

--- a/doc/toml/gy6or6_train.toml
+++ b/doc/toml/gy6or6_train.toml
@@ -18,6 +18,8 @@ labelset = "iabcdefghjk"
 train_dur = 50
 # val_dur: duration of validation split in dataset, in seconds
 val_dur = 15
+# test_dur: duration of test split in dataset, in seconds
+val_dur = 30
 
 # SPECT_PARAMS: parameters for computing spectrograms
 [SPECT_PARAMS]
@@ -32,7 +34,7 @@ step_size = 64
 # model: the string name of the model. must be a name within `vak.models` or added e.g. with `vak.model.decorators.model`
 model = "TweetyNet"
 # root_results_dir: directory where results should be saved, as a sub-directory within `root_results_dir`
-root_results_dir = "/PATH/TO/DATA/vak/train/results"
+root_results_dir = "/PATH/TO/DATA/vak/results/train"
 # batch_size: number of samples from dataset per batch fed into network
 batch_size = 8
 # num_epochs: number of training epochs, where an epoch is one iteration through all samples in training split
@@ -54,6 +56,7 @@ patience = 4
 num_workers = 4
 # device: name of device to run model on, one of "cuda", "cpu"
 device = "cuda"
+# dataset_path : path to dataset created by prep. This will be added when you run `vak prep`, you don't have to add it
 
 # train_dataset_params: parameters used when loading training dataset
 # for a frame classification model, we use a WindowDataset with a specific `window_size`

--- a/tests/data_for_tests/configs/TweetyNet_eval_audio_cbin_annot_notmat.toml
+++ b/tests/data_for_tests/configs/TweetyNet_eval_audio_cbin_annot_notmat.toml
@@ -24,6 +24,10 @@ device = "cuda"
 spect_scaler_path = "~/Documents/repos/coding/birdsong/TweetyNet/results/BFSongRepository/gy6or6/results_200620_165308/StandardizeSpect"
 output_dir = "./tests/data_for_tests/generated/results/eval/audio_cbin_annot_notmat/TweetyNet"
 
+[EVAL.post_tfm_kwargs]
+majority_vote = true
+min_segment_dur = 0.02
+
 [EVAL.transform_params]
 window_size = 88
 

--- a/tests/data_for_tests/configs/TweetyNet_learncurve_audio_cbin_annot_notmat.toml
+++ b/tests/data_for_tests/configs/TweetyNet_learncurve_audio_cbin_annot_notmat.toml
@@ -31,6 +31,10 @@ num_workers = 16
 device = "cuda"
 root_results_dir = "./tests/data_for_tests/generated/results/learncurve/audio_cbin_annot_notmat/TweetyNet"
 
+[LEARNCURVE.post_tfm_kwargs]
+majority_vote = true
+min_segment_dur = 0.02
+
 [LEARNCURVE.train_dataset_params]
 window_size = 88
 


### PR DESCRIPTION
This also fixes the video link on the index.md, and adds a couple eval/learncurve configs to the tests that have `post_tfm_kwargs` arguments