### PR TITLE
TST: Fix test in `common.labels`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ license = {file = "LICENSE"}
 dependencies = [
     "attrs >=19.3.0",
     "crowsetta >=5.0.1",
-    "dask >=2.10.1",
+    "dask[dataframe] >=2.10.1",
     "evfuncs >=0.3.4",
     "joblib >=0.14.1",
     "pytorch-lightning >=2.0.7",

--- a/tests/test_common/test_labels.py
+++ b/tests/test_common/test_labels.py
@@ -1,7 +1,7 @@
 import copy
-import pathlib
 
 import numpy as np
+import pandas as pd
 import pytest
 
 import vak.common.files.spect
@@ -72,7 +72,7 @@ def test_from_df(config_type, model_name, audio_format, spect_format, annot_form
 
     out = vak.common.labels.from_df(df, dataset_path)
     assert isinstance(out, list)
-    assert all([isinstance(labels, np.ndarray) for labels in out])
+    assert all([isinstance(labels, (np.ndarray, pd.arrays.StringArray)) for labels in out])
 
 
 INTS_LABELMAP = {str(val): val for val in range(1, 20)}


### PR DESCRIPTION
This fixes a test that fails because in some cases `pandas` is converting the `labels` column to a `pandas.arrays.StringArray`.

I am fixing by just broadening the assertion to check whether `isinstance(labels, (numpy.ndarray, pandas.arrays.StringArray))`.

I need to investigate further but it doesn't seem to be breaking anything else right now.

I also added the dependency on the `dask` extra `dataframe` to squelch a warning we get every time we call `dask.bag` and `dask.delayed`.