### PR TITLE
CLN: Refactor model abstraction, fix #737 #726

### DIFF
--- a/src/vak/common/tensorboard.py
+++ b/src/vak/common/tensorboard.py
@@ -128,5 +128,5 @@ def events2df(
         ).set_index("step")
         if drop_wall_time:
             dfs[scalar_tag].drop("wall_time", axis=1, inplace=True)
-    df = pd.concat([v for k, v in dfs.items()], axis=1)
+    df = pd.concat([v for k, v in dfs.items() if k != "epoch"], axis=1)
     return df

--- a/src/vak/config/model.py
+++ b/src/vak/config/model.py
@@ -78,6 +78,8 @@ class ModelConfig:
                 f"Model name not found in registry: {model_name}\n"
                 f"Model names in registry:\n{MODEL_NAMES}"
             )
+
+        # NOTE: we are getting model_config here
         model_config = config_dict[model_name]
         if not all(key in MODEL_TABLES for key in model_config.keys()):
             invalid_keys = (
@@ -89,7 +91,7 @@ class ModelConfig:
             )
         # for any tables not specified, default to empty dict so we can still use ``**`` operator on it
         for model_table in MODEL_TABLES:
-            if model_table not in config_dict:
+            if model_table not in model_config:
                 model_config[model_table] = {}
         return cls(name=model_name, **model_config)
 

--- a/src/vak/models/__init__.py
+++ b/src/vak/models/__init__.py
@@ -1,5 +1,5 @@
-from . import base, decorator, definition, registry
-from .base import Model
+from . import decorator, definition, factory, registry
+from .factory import ModelFactory
 from .convencoder_umap import ConvEncoderUMAP
 from .decorator import model
 from .ed_tcn import ED_TCN
@@ -10,14 +10,14 @@ from .registry import model_family
 from .tweetynet import TweetyNet
 
 __all__ = [
-    "base",
+    "factory",
     "ConvEncoderUMAP",
     "decorator",
     "definition",
     "ED_TCN",
     "FrameClassificationModel",
     "get",
-    "Model",
+    "ModelFactory",
     "model",
     "model_family",
     "ParametricUMAPModel",

--- a/src/vak/models/base.py
+++ b/src/vak/models/base.py
@@ -371,7 +371,7 @@ class Model:
         return network, loss, optimizer, metrics
 
     def from_config(self, config: dict, **kwargs):
-        """Return an initialized model instance from a config ``dict``
+        """Return a a new instance of a model, given a config ``dict``
 
         Parameters
         ----------
@@ -386,6 +386,44 @@ class Model:
             initialized using parameters from ``config``.
         """
         network, loss, optimizer, metrics = self.attributes_from_config(config)
+        network, loss, optimizer, metrics = self.validate_instances_or_get_default(
+            network, loss, optimizer, metrics,
+        )
+        return self.family(
+            network=network, loss=loss, optimizer=optimizer, metrics=metrics, **kwargs
+        )
+
+    def from_instances(
+        self,
+        network: torch.nn.Module | dict | None = None,
+        loss: torch.nn.Module | Callable | None = None,
+        optimizer: torch.optim.Optimizer | None = None,
+        metrics: dict | None = None,
+        **kwargs,
+    ):
+        """
+
+        Parameters
+        ----------
+        network : torch.nn.Module, dict
+            An instance of a ``torch.nn.Module``
+            that implements a neural network,
+            or a ``dict`` that maps human-readable string names
+            to a set of such instances.
+        loss : torch.nn.Module, callable
+            An instance of a ``torch.nn.Module``
+            that implements a loss function,
+            or a callable Python function that
+            computes a scalar loss.
+        optimizer : torch.optim.Optimizer
+            An instance of a ``torch.optim.Optimizer`` class
+            used with ``loss`` to optimize
+            the parameters of ``network``.
+        metrics : dict
+            A ``dict`` that maps human-readable string names
+            to ``Callable`` functions, used to measure
+            performance of the model.
+        """
         network, loss, optimizer, metrics = self.validate_instances_or_get_default(
             network, loss, optimizer, metrics,
         )

--- a/src/vak/models/base.py
+++ b/src/vak/models/base.py
@@ -33,14 +33,234 @@ class Model:
     definition: ClassVar[ModelDefinition]
     model_family: ClassVar[lightning.pytorch.LightningModule]
 
-    def __init__(
+    def __init__(self) -> None:
+        pass
+
+    def attributes_from_config(self, config: dict):
+        """Get attributes for an instance of a model,
+        given a configuration.
+
+        Given a :class:`dict`, ``config``, return instances
+        of `network`, `optimizer`, `loss`, and `metrics`.
+
+        Parameters
+        ----------
+        config : dict
+            A :class:`dict` obtained by calling
+            :meth:`vak.config.ModelConfig.to_dict()`.
+
+        Returns
+        -------
+        network : torch.nn.Module, dict
+            An instance of a ``torch.nn.Module``
+            that implements a neural network,
+            or a ``dict`` that maps human-readable string names
+            to a set of such instances.
+        loss : torch.nn.Module, callable
+            An instance of a ``torch.nn.Module``
+            that implements a loss function.
+        optimizer : torch.optim.Optimizer
+            An instance of a ``torch.optim.Optimizer`` class
+            used with ``loss`` to optimize
+            the parameters of ``network``.
+        metrics : dict
+            A ``dict`` that maps human-readable string names
+            to ``Callable`` functions, used to measure
+            performance of the model.
+        """
+        network_kwargs = config.get(
+            "network", self.definition.default_config["network"]
+        )
+        if inspect.isclass(self.definition.network):
+            network = self.definition.network(**network_kwargs)
+        elif isinstance(self.definition.network, dict):
+            network = {}
+            for net_name, net_class in self.definition.network.items():
+                net_class_kwargs = network_kwargs.get(net_name, {})
+                network[net_name] = net_class(**net_class_kwargs)
+
+        if isinstance(self.definition.network, dict):
+            params = [
+                param
+                for net_name, net_instance in network.items()
+                for param in net_instance.parameters()
+            ]
+        else:
+            params = network.parameters()
+
+        optimizer_kwargs = config.get(
+            "optimizer", self.definition.default_config["optimizer"]
+        )
+        optimizer = self.definition.optimizer(params=params, **optimizer_kwargs)
+
+        if inspect.isclass(self.definition.loss):
+            loss_kwargs = config.get(
+                "loss", self.definition.default_config["loss"]
+            )
+            loss = self.definition.loss(**loss_kwargs)
+        else:
+            loss = self.definition.loss
+
+        metrics_config = config.get(
+            "metrics", self.definition.default_config["metrics"]
+        )
+        metrics = {}
+        for metric_name, metric_class in self.definition.metrics.items():
+            metrics_class_kwargs = metrics_config.get(metric_name, {})
+            metrics[metric_name] = metric_class(**metrics_class_kwargs)
+
+        return network, loss, optimizer, metrics
+
+    def validate_init(
         self,
         network: torch.nn.Module | dict | None = None,
         loss: torch.nn.Module | Callable | None = None,
         optimizer: torch.optim.Optimizer | None = None,
         metrics: dict | None = None,
     ):
-        """Initializes an instance of a model, using its definition.
+        """Validate arguments to ``vak.models.base.Model.init``.
+
+        Parameters
+        ----------
+        network : torch.nn.Module, dict
+            An instance of a ``torch.nn.Module``
+            that implements a neural network,
+            or a ``dict`` where each key is a string
+             that maps a human-readable name
+            to a ``torch.nn.Module`` instance.
+        loss : torch.nn.Module, callable
+            An instance of a ``torch.nn.Module``
+            that implements a loss function,
+            or a callable Python function that
+            computes a scalar loss.
+        optimizer : torch.optim.Optimizer
+            An instance of a ``torch.optim.Optimizer`` class
+            used with ``loss`` to optimize
+            the parameters of ``network``.
+        metrics : dict
+            A ``dict`` that maps human-readable string names
+            to ``Callable`` functions, used to measure
+            performance of the model.
+
+        Returns
+        -------
+        None
+
+        This method does not return values;
+        it just raises an error if any value is invalid.
+        """
+        if network:
+            if inspect.isclass(self.definition.network):
+                if not isinstance(network, self.definition.network):
+                    raise TypeError(
+                        f"``network`` should be an instance of {self.definition.network}"
+                        f"but was of type {type(network)}"
+                    )
+
+            elif isinstance(self.definition.network, dict):
+                if not isinstance(network, dict):
+                    raise TypeError(
+                        "Expected ``network`` to be a ``dict`` mapping network names "
+                        f"to ``torch.nn.Module`` instances, but type was {type(network)}"
+                    )
+                expected_network_dict_keys = list(
+                    self.definition.network.keys()
+                )
+                network_dict_keys = list(network.keys())
+                if not all(
+                    [
+                        expected_network_dict_key in network_dict_keys
+                        for expected_network_dict_key in expected_network_dict_keys
+                    ]
+                ):
+                    missing_keys = set(expected_network_dict_keys) - set(
+                        network_dict_keys
+                    )
+                    raise ValueError(
+                        f"The following keys were missing from the ``network`` dict: {missing_keys}"
+                    )
+                if any(
+                    [
+                        network_dict_key not in expected_network_dict_keys
+                        for network_dict_key in network_dict_keys
+                    ]
+                ):
+                    extra_keys = set(network_dict_keys) - set(
+                        expected_network_dict_keys
+                    )
+                    raise ValueError(
+                        f"The following keys in the ``network`` dict are not valid: {extra_keys}."
+                        f"Valid keys are: {expected_network_dict_keys}"
+                    )
+
+                for network_name, network_instance in network.items():
+                    if not isinstance(
+                        network_instance, self.definition.network[network_name]
+                    ):
+                        raise TypeError(
+                            f"Network with name '{network_name}' in ``network`` dict "
+                            f"should be an instance of {self.definition.network[network_name]}"
+                            f"but was of type {type(network)}"
+                        )
+            else:
+                raise TypeError(
+                    f"Invalid type for ``network``: {type(network)}"
+                )
+
+        if loss:
+            if issubclass(self.definition.loss, torch.nn.Module):
+                if not isinstance(loss, self.definition.loss):
+                    raise TypeError(
+                        f"``loss`` should be an instance of {self.definition.loss}"
+                        f"but was of type {type(loss)}"
+                    )
+            elif callable(self.definition.loss):
+                if loss is not self.definition.loss:
+                    raise ValueError(
+                        f"``loss`` should be the following callable (probably a function): {self.definition.loss}"
+                    )
+            else:
+                raise TypeError(f"Invalid type for ``loss``: {type(loss)}")
+
+        if optimizer:
+            if not isinstance(optimizer, self.definition.optimizer):
+                raise TypeError(
+                    f"``optimizer`` should be an instance of {self.definition.optimizer}"
+                    f"but was of type {type(optimizer)}"
+                )
+
+        if metrics:
+            if not isinstance(metrics, dict):
+                raise TypeError(
+                    "``metrics`` should be a ``dict`` mapping string metric names "
+                    f"to callable metrics, but type of ``metrics`` was {type(metrics)}"
+                )
+            for metric_name, metric_callable in metrics.items():
+                if metric_name not in self.definition.metrics:
+                    raise ValueError(
+                        f"``metrics`` has name '{metric_name}' but that name "
+                        f"is not in the model definition. "
+                        f"Valid metric names are: {', '.join(list(self.definition.metrics.keys()))}"
+                    )
+
+                if not isinstance(
+                    metric_callable, self.definition.metrics[metric_name]
+                ):
+                    raise TypeError(
+                        f"metric '{metric_name}' should be an instance of {self.definition.metrics[metric_name]}"
+                        f"but was of type {type(metric_callable)}"
+                    )
+
+    def validate_instances_or_get_default(
+        self,
+        network: torch.nn.Module | dict | None = None,
+        loss: torch.nn.Module | Callable | None = None,
+        optimizer: torch.optim.Optimizer | None = None,
+        metrics: dict | None = None,
+    ):
+        """Validate instances of model attributes, using its definition,
+        or if no instance is passed in for an attribute,
+        make an instance using the default config.
 
         Takes in instances of the attributes defined by the class variable
         ``self.definition``: ``network``, ``loss``, ``optimizer``, and ``metrics``.
@@ -99,7 +319,6 @@ class Model:
                 }
             else:
                 network = self.definition.network(**net_kwargs)
-        self.network = network
 
         if loss is None:
             if inspect.isclass(self.definition.loss):
@@ -107,7 +326,6 @@ class Model:
                 loss = self.definition.loss(**loss_kwargs)
             elif inspect.isfunction(self.definition.loss):
                 loss = self.definition.loss
-        self.loss = loss
 
         if optimizer is None:
             optimizer_kwargs = self.definition.default_config.get("optimizer")
@@ -122,7 +340,6 @@ class Model:
             optimizer = self.definition.optimizer(
                 params=params, **optimizer_kwargs
             )
-        self.optimizer = optimizer
 
         if metrics is None:
             metric_kwargs = self.definition.default_config.get("metrics")
@@ -130,256 +347,6 @@ class Model:
             for metric_name, metric_class in self.definition.metrics.items():
                 metric_class_kwargs = metric_kwargs.get(metric_name, {})
                 metrics[metric_name] = metric_class(**metric_class_kwargs)
-        self.metrics = metrics
-
-    @classmethod
-    def validate_init(
-        cls,
-        network: torch.nn.Module | dict | None = None,
-        loss: torch.nn.Module | Callable | None = None,
-        optimizer: torch.optim.Optimizer | None = None,
-        metrics: dict | None = None,
-    ):
-        """Validate arguments to ``vak.models.base.Model.__init__``.
-
-        Parameters
-        ----------
-        network : torch.nn.Module, dict
-            An instance of a ``torch.nn.Module``
-            that implements a neural network,
-            or a ``dict`` where each key is a string
-             that maps a human-readable name
-            to a ``torch.nn.Module`` instance.
-        loss : torch.nn.Module, callable
-            An instance of a ``torch.nn.Module``
-            that implements a loss function,
-            or a callable Python function that
-            computes a scalar loss.
-        optimizer : torch.optim.Optimizer
-            An instance of a ``torch.optim.Optimizer`` class
-            used with ``loss`` to optimize
-            the parameters of ``network``.
-        metrics : dict
-            A ``dict`` that maps human-readable string names
-            to ``Callable`` functions, used to measure
-            performance of the model.
-
-        Returns
-        -------
-        None
-
-        This method does not return values;
-        it just raises an error if any value is invalid.
-        """
-        if network:
-            if inspect.isclass(cls.definition.network):
-                if not isinstance(network, cls.definition.network):
-                    raise TypeError(
-                        f"``network`` should be an instance of {cls.definition.network}"
-                        f"but was of type {type(network)}"
-                    )
-
-            elif isinstance(cls.definition.network, dict):
-                if not isinstance(network, dict):
-                    raise TypeError(
-                        "Expected ``network`` to be a ``dict`` mapping network names "
-                        f"to ``torch.nn.Module`` instances, but type was {type(network)}"
-                    )
-                expected_network_dict_keys = list(
-                    cls.definition.network.keys()
-                )
-                network_dict_keys = list(network.keys())
-                if not all(
-                    [
-                        expected_network_dict_key in network_dict_keys
-                        for expected_network_dict_key in expected_network_dict_keys
-                    ]
-                ):
-                    missing_keys = set(expected_network_dict_keys) - set(
-                        network_dict_keys
-                    )
-                    raise ValueError(
-                        f"The following keys were missing from the ``network`` dict: {missing_keys}"
-                    )
-                if any(
-                    [
-                        network_dict_key not in expected_network_dict_keys
-                        for network_dict_key in network_dict_keys
-                    ]
-                ):
-                    extra_keys = set(network_dict_keys) - set(
-                        expected_network_dict_keys
-                    )
-                    raise ValueError(
-                        f"The following keys in the ``network`` dict are not valid: {extra_keys}."
-                        f"Valid keys are: {expected_network_dict_keys}"
-                    )
-
-                for network_name, network_instance in network.items():
-                    if not isinstance(
-                        network_instance, cls.definition.network[network_name]
-                    ):
-                        raise TypeError(
-                            f"Network with name '{network_name}' in ``network`` dict "
-                            f"should be an instance of {cls.definition.network[network_name]}"
-                            f"but was of type {type(network)}"
-                        )
-            else:
-                raise TypeError(
-                    f"Invalid type for ``network``: {type(network)}"
-                )
-
-        if loss:
-            if issubclass(cls.definition.loss, torch.nn.Module):
-                if not isinstance(loss, cls.definition.loss):
-                    raise TypeError(
-                        f"``loss`` should be an instance of {cls.definition.loss}"
-                        f"but was of type {type(loss)}"
-                    )
-            elif callable(cls.definition.loss):
-                if loss is not cls.definition.loss:
-                    raise ValueError(
-                        f"``loss`` should be the following callable (probably a function): {cls.definition.loss}"
-                    )
-            else:
-                raise TypeError(f"Invalid type for ``loss``: {type(loss)}")
-
-        if optimizer:
-            if not isinstance(optimizer, cls.definition.optimizer):
-                raise TypeError(
-                    f"``optimizer`` should be an instance of {cls.definition.optimizer}"
-                    f"but was of type {type(optimizer)}"
-                )
-
-        if metrics:
-            if not isinstance(metrics, dict):
-                raise TypeError(
-                    "``metrics`` should be a ``dict`` mapping string metric names "
-                    f"to callable metrics, but type of ``metrics`` was {type(metrics)}"
-                )
-            for metric_name, metric_callable in metrics.items():
-                if metric_name not in cls.definition.metrics:
-                    raise ValueError(
-                        f"``metrics`` has name '{metric_name}' but that name "
-                        f"is not in the model definition. "
-                        f"Valid metric names are: {', '.join(list(cls.definition.metrics.keys()))}"
-                    )
-
-                if not isinstance(
-                    metric_callable, cls.definition.metrics[metric_name]
-                ):
-                    raise TypeError(
-                        f"metric '{metric_name}' should be an instance of {cls.definition.metrics[metric_name]}"
-                        f"but was of type {type(metric_callable)}"
-                    )
-
-    def load_state_dict_from_path(self, ckpt_path):
-        """Loads a model from the path to a saved checkpoint.
-
-        Loads the checkpoint and then calls
-        ``self.load_state_dict`` with the ``state_dict``
-        in that chekcpoint.
-
-        This method allows loading a state dict into an instance.
-        It's necessary because `lightning.pytorch.LightningModule.load`` is a
-        ``classmethod``, so calling that method will trigger
-         ``LightningModule.__init__`` instead of running
-        ``vak.models.Model.__init__``.
-
-        Parameters
-        ----------
-        ckpt_path : str, pathlib.Path
-            Path to a checkpoint saved by a model in ``vak``.
-            This checkpoint has the same key-value pairs as
-            any other checkpoint saved by a
-            ``lightning.pytorch.LightningModule``.
-
-        Returns
-        -------
-        None
-
-        This method modifies the model state by loading the ``state_dict``;
-        it does not return anything.
-        """
-        ckpt = torch.load(ckpt_path)
-        self.load_state_dict(ckpt["state_dict"])
-
-    @classmethod
-    def attributes_from_config(cls, config: dict):
-        """Get attributes for an instance of a model,
-        given a configuration.
-
-        Given a :class:`dict`, ``config``, return instances of
-        class variables.
-
-        Parameters
-        ----------
-        config : dict
-            A :class:`dict` obtained by calling
-            :meth:`vak.config.ModelConfig.to_dict()`.
-
-        Returns
-        -------
-        network : torch.nn.Module, dict
-            An instance of a ``torch.nn.Module``
-            that implements a neural network,
-            or a ``dict`` that maps human-readable string names
-            to a set of such instances.
-        loss : torch.nn.Module, callable
-            An instance of a ``torch.nn.Module``
-            that implements a loss function,
-            or a callable Python function that
-            computes a scalar loss.
-        optimizer : torch.optim.Optimizer
-            An instance of a ``torch.optim.Optimizer`` class
-            used with ``loss`` to optimize
-            the parameters of ``network``.
-        metrics : dict
-            A ``dict`` that maps human-readable string names
-            to ``Callable`` functions, used to measure
-            performance of the model.
-        """
-        network_kwargs = config.get(
-            "network", cls.definition.default_config["network"]
-        )
-        if inspect.isclass(cls.definition.network):
-            network = cls.definition.network(**network_kwargs)
-        elif isinstance(cls.definition.network, dict):
-            network = {}
-            for net_name, net_class in cls.definition.network.items():
-                net_class_kwargs = network_kwargs.get(net_name, {})
-                network[net_name] = net_class(**net_class_kwargs)
-
-        if isinstance(cls.definition.network, dict):
-            params = [
-                param
-                for net_name, net_instance in network.items()
-                for param in net_instance.parameters()
-            ]
-        else:
-            params = network.parameters()
-
-        optimizer_kwargs = config.get(
-            "optimizer", cls.definition.default_config["optimizer"]
-        )
-        optimizer = cls.definition.optimizer(params=params, **optimizer_kwargs)
-
-        if inspect.isclass(cls.definition.loss):
-            loss_kwargs = config.get(
-                "loss", cls.definition.default_config["loss"]
-            )
-            loss = cls.definition.loss(**loss_kwargs)
-        else:
-            loss = cls.definition.loss
-
-        metrics_config = config.get(
-            "metrics", cls.definition.default_config["metrics"]
-        )
-        metrics = {}
-        for metric_name, metric_class in cls.definition.metrics.items():
-            metrics_class_kwargs = metrics_config.get(metric_name, {})
-            metrics[metric_name] = metric_class(**metrics_class_kwargs)
-
         return network, loss, optimizer, metrics
 
     def from_config(self, config: dict, **kwargs):
@@ -398,6 +365,9 @@ class Model:
             initialized using parameters from ``config``.
         """
         network, loss, optimizer, metrics = self.attributes_from_config(config)
+        network, loss, optimizer, metrics = self.validate_instances_or_get_default(
+            network, loss, optimizer, metrics,
+        )
         return self.model_family(
             network=network, loss=loss, optimizer=optimizer, metrics=metrics, **kwargs
         )

--- a/src/vak/models/base.py
+++ b/src/vak/models/base.py
@@ -1,6 +1,4 @@
-"""Base class for a model in ``vak``,
-that other families of models should subclass.
-"""
+"""Class that represent a model builit into ``vak``."""
 
 from __future__ import annotations
 
@@ -14,27 +12,26 @@ from .definition import ModelDefinition
 from .definition import validate as validate_definition
 
 
-class Model(lightning.pytorch.LightningModule):
-    """Base class for a model in ``vak``,
-    that other families of models should subclass.
+class Model:
+    """Class that represent a model builit into ``vak``.
 
-    This class provides methods for working with
-    neural network models, e.g. training the model
-    and generating productions,
-    and it also converts a
-    model definition into a model instance.
+    Attributes
+    ----------
+    definition: vak.models.definition.ModelDefinition
+    family: lighting.pytorch.LightningModule
 
-    It provides the methods for working with neural
-    network models by subclassing
-    ``lighting.LightningModule``, and it handles
-    converting a model definition into a model instance
-    inside its ``__init__`` method.
-    Model definitions are declared programmatically
-    using a ``vak.model.ModelDefinition``;
-    see the documentation on that class for more detail.
+    Notes
+    -----
+    This class is used by the :func:`vak.models.decorator.model`
+    decorator to make a new class representing a model
+    from a model definition.
+    As such, this class is not meant to be used directly.
+    See the docstring of :func:`vak.models.decorator.model`
+    for more detail.
     """
 
     definition: ClassVar[ModelDefinition]
+    model_family: ClassVar[lightning.pytorch.LightningModule]
 
     def __init__(
         self,
@@ -74,8 +71,6 @@ class Model(lightning.pytorch.LightningModule):
             performance of the model.
         """
         from .decorator import ModelDefinitionValidationError
-
-        super().__init__()
 
         # check that we are a sub-class of some other class with required class variables
         if not hasattr(self, "definition"):
@@ -314,14 +309,14 @@ class Model(lightning.pytorch.LightningModule):
         """Get attributes for an instance of a model,
         given a configuration.
 
-        Given a ``dict``, ``config``, return instances of
-        class variables
+        Given a :class:`dict`, ``config``, return instances of
+        class variables.
 
         Parameters
         ----------
         config : dict
-            Returned by calling ``vak.config.models.map_from_path``
-            or ``vak.config.models.map_from_config_dict``.
+            A :class:`dict` obtained by calling
+            :meth:`vak.config.ModelConfig.to_dict()`.
 
         Returns
         -------
@@ -387,8 +382,7 @@ class Model(lightning.pytorch.LightningModule):
 
         return network, loss, optimizer, metrics
 
-    @classmethod
-    def from_config(cls, config: dict):
+    def from_config(self, config: dict, **kwargs):
         """Return an initialized model instance from a config ``dict``
 
         Parameters
@@ -403,7 +397,7 @@ class Model(lightning.pytorch.LightningModule):
             An instance of the model with its attributes
             initialized using parameters from ``config``.
         """
-        network, loss, optimizer, metrics = cls.attributes_from_config(config)
-        return cls(
-            network=network, loss=loss, optimizer=optimizer, metrics=metrics
+        network, loss, optimizer, metrics = self.attributes_from_config(config)
+        return self.model_family(
+            network=network, loss=loss, optimizer=optimizer, metrics=metrics, **kwargs
         )

--- a/src/vak/models/decorator.py
+++ b/src/vak/models/decorator.py
@@ -1,23 +1,25 @@
-"""Decorator that makes a model class,
+"""Decorator that makes a :class:`vak.models.ModelFactory`,
 given a definition of the model,
-and another class that represents a
+and a :class:`lightning.LightningModule` that represents a
 family of models that the new model belongs to.
 
-The function returns a newly-created subclass
-of the class representing the family of models.
-The subclass can then be instantiated
-and have all model methods.
+The function returns a new instance of :class:`vak.models.ModelFactory`,
+that can create new instances of the model with its
+:meth:`~:class:`vak.models.ModelFactory.from_config` and
+:meth:`~:class:`vak.models.ModelFactory.from_instances` methods.
 """
 
 from __future__ import annotations
 
-from typing import Type
+from typing import Type, TYPE_CHECKING
 
 import lightning
 
 from .definition import validate as validate_definition
 from .registry import register_model
 
+if TYPE_CHECKING:
+    from .factory import ModelFactory
 
 class ModelDefinitionValidationError(Exception):
     """Exception raised when validating a model
@@ -30,15 +32,15 @@ class ModelDefinitionValidationError(Exception):
 
 
 def model(family: lightning.pytorch.LightningModule):
-    """Decorator that makes a model class,
+    """Decorator that makes a :class:`vak.models.ModelFactory`,
     given a definition of the model,
-    and another class that represents a
+    and a :class:`lightning.LightningModule` that represents a
     family of models that the new model belongs to.
 
-    Returns a newly-created subclass
-    of the class representing the family of models.
-    The subclass can then be instantiated
-    and have all model methods.
+    The function returns a new instance of :class:`vak.models.ModelFactory`,
+    that can create new instances of the model with its
+    :meth:`~:class:`vak.models.ModelFactory.from_config` and
+    :meth:`~:class:`vak.models.ModelFactory.from_instances` methods.
 
     Parameters
     ----------
@@ -51,34 +53,36 @@ def model(family: lightning.pytorch.LightningModule):
         but note that it is not necessary to subclass
         :class:`~vak.models.definition.ModelDefinition` to
         define a model.
-    family : lightning.pytorch.LightningModule
+    family : lightning.LightningModule
         The class representing the family of models
         that the new model will belong to.
         E.g., :class:`vak.models.FrameClassificationModel`.
+        Should be a subclass of :class:`lightning.LightningModule`
+        that was registered with the
+        :func:`vak.models.registry.model_family` decorator.
 
     Returns
     -------
-    model : type
-        A sub-class of :class:`~vak.models.base.Model`,
-        with attribute ``definition``
-        and ``family``,
+    model_factory : vak.models.ModelFactory
+        An instance of :class:`~vak.models.ModelFactory`,
+        with attribute ``definition`` and ``family``,
         that will be used when making
-        new instances of the model
-        by calling the
-        :meth:`~vak.models.base.Model.from_config` method.
+        new instances of the model by calling the
+        :meth:`~vak.models.ModelFactory.from_config` method
+        or the :meth:`~:class:`vak.models.ModelFactory.from_instances` method.
     """
 
-    def _model(definition: Type):
+    def _model(definition: Type) -> ModelFactory:
         from .factory import ModelFactory  # avoid circular import
 
-        model = ModelFactory(
+        model_factory = ModelFactory(
             definition,
             family
         )
-        model.__name__ = definition.__name__
-        model.__doc__ = definition.__doc__
-        model.__module__ = definition.__module__
-        register_model(model)
-        return model
+        model_factory.__name__ = definition.__name__
+        model_factory.__doc__ = definition.__doc__
+        model_factory.__module__ = definition.__module__
+        register_model(model_factory)
+        return model_factory
 
     return _model

--- a/src/vak/models/decorator.py
+++ b/src/vak/models/decorator.py
@@ -69,9 +69,9 @@ def model(family: lightning.pytorch.LightningModule):
     """
 
     def _model(definition: Type):
-        from .base import Model  # avoid circular import
+        from .factory import ModelFactory  # avoid circular import
 
-        model = Model(
+        model = ModelFactory(
             definition,
             family
         )

--- a/src/vak/models/decorator.py
+++ b/src/vak/models/decorator.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 from typing import Type
 
+import lightning
+
 from .base import Model
 from .definition import validate as validate_definition
 from .registry import register_model
@@ -28,7 +30,7 @@ class ModelDefinitionValidationError(Exception):
     pass
 
 
-def model(family: Type[Model]):
+def model(family: lightning.pytorch.LightningModule):
     """Decorator that makes a model class,
     given a definition of the model,
     and another class that represents a
@@ -46,7 +48,11 @@ def model(family: Type[Model]):
         A class with all the class variables required
         by :func:`vak.models.definition.validate`.
         See docstring of that function for specification.
-    family : subclass of vak.models.Model
+        See also :class:`vak.models.definition.ModelDefinition`,
+        but note that it is not necessary to subclass
+        :class:`~vak.models.definition.ModelDefinition` to
+        define a model.
+    family : lightning.pytorch.LightningModule
         The class representing the family of models
         that the new model will belong to.
         E.g., :class:`vak.models.FrameClassificationModel`.
@@ -54,20 +60,23 @@ def model(family: Type[Model]):
     Returns
     -------
     model : type
-        A sub-class of ``model_family``,
-        with attribute ``definition``,
+        A sub-class of :class:`~vak.models.base.Model`,
+        with attribute ``definition``
+        and ``family``,
         that will be used when making
-        new instances of the model.
+        new instances of the model
+        by calling the
+        :meth:`~vak.models.base.Model.from_config` method.
     """
 
     def _model(definition: Type):
-        if not issubclass(family, Model):
+        if not issubclass(family, lightning.pytorch.LightningModule):
             raise TypeError(
                 "The ``family`` argument to the ``vak.models.model`` decorator"
-                "should be a subclass of ``vak.models.base.Model``,"
+                "should be a subclass of ``lightning.pytorch.LightningModule``,"
                 f"but the type was: {type(family)}, "
                 "which was not recognized as a subclass "
-                "of ``vak.models.base.Model``."
+                "of ``lightning.pytorch.LightningModule``."
             )
 
         try:
@@ -83,13 +92,15 @@ def model(family: Type[Model]):
 
         attributes = dict(family.__dict__)
         attributes.update({"definition": definition})
+        attributes.update({"family": family})
         subclass_name = definition.__name__
-        subclass = type(subclass_name, (family,), attributes)
+        subclass = type(subclass_name, (Model,), attributes)
         subclass.__module__ = definition.__module__
 
+        instance = subclass()
         # finally, add model to registry
-        register_model(subclass)
+        register_model(instance)
 
-        return subclass
+        return instance
 
     return _model

--- a/src/vak/models/definition.py
+++ b/src/vak/models/definition.py
@@ -67,7 +67,7 @@ DEFAULT_DEFAULT_CONFIG = {
 }
 
 
-def validate(definition: Type[ModelDefinition]) -> Type[ModelDefinition]:
+def validate(definition: Type) -> Type:
     """Validate a model definition.
 
     A model definition is a class that has the following class variables:

--- a/src/vak/models/definition.py
+++ b/src/vak/models/definition.py
@@ -27,10 +27,7 @@ VALID_CONFIG_KEYS = REQUIRED_MODEL_DEFINITION_CLASS_VARS[
 class ModelDefinition:
     """A class that represents the definition of a neural network model.
 
-    Note it is **not** necessary to sub-class this class;
-    it exists mainly for type-checking purposes.
-
-    A model definition is a class that has the following class variables:
+    A model definition is any class that has the following class variables:
 
     network: torch.nn.Module or dict
         Neural network.
@@ -48,6 +45,12 @@ class ModelDefinition:
         Used by ``vak.models.base.Model`` and its
         sub-classes that represent model families. E.g., those classes will do:
         ``network = self.definition.network(**self.definition.default_config['network'])``.
+
+    Note it is **not** necessary to sub-class this class;
+    it exists mainly for type-checking purposes.
+
+    For more detail, see :func:`vak.models.decorator.model`
+    and :class:`vak.models.ModelFactory`.
     """
 
     network: Union[torch.nn.Module, dict]
@@ -124,8 +127,8 @@ def validate(definition: Type) -> Type:
     converting it into a sub-class ofhttps://peps.python.org/pep-0416/
     ``vak.models.Model``.
 
-    It's also used by ``vak.models.Model``
-    to validate a definition when initializing
+    It's also used by :class:`vak.models.ModelFactory`,
+    to validate a definition before building 
     a new model instance from the definition.
     """
     # need to set this default first

--- a/src/vak/models/factory.py
+++ b/src/vak/models/factory.py
@@ -371,19 +371,19 @@ class ModelFactory:
         return network, loss, optimizer, metrics
 
     def from_config(self, config: dict, **kwargs):
-        """Return a a new instance of a model, given a config ``dict``
+        """Return a a new instance of a model, given a config :class:`dict`.
 
         Parameters
         ----------
         config : dict
-            Returned by calling ``vak.config.models.map_from_path``
-            or ``vak.config.models.map_from_config_dict``.
+            The dict obtained by by calling :meth:`vak.config.ModelConfig.asdict`.
 
         Returns
         -------
-        cls : vak.models.base.Model
-            An instance of the model with its attributes
-            initialized using parameters from ``config``.
+        model : lightning.LightningModule
+            An instance of the model :attr:`~ModelFactory.family`
+            with attributes specified by :attr:`~ModelFactory.definition`,
+            that are initialized using parameters from ``config``.
         """
         network, loss, optimizer, metrics = self.attributes_from_config(config)
         network, loss, optimizer, metrics = self.validate_instances_or_get_default(

--- a/src/vak/models/factory.py
+++ b/src/vak/models/factory.py
@@ -12,7 +12,7 @@ from .definition import validate as validate_definition
 from .decorator import ModelDefinitionValidationError
 
 
-class Model:
+class ModelFactory:
     """Class that represent a model builit into ``vak``.
 
     Attributes

--- a/src/vak/models/frame_classification_model.py
+++ b/src/vak/models/frame_classification_model.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 from typing import Callable, Mapping
 
-import pytorch_lightning as lightning
+import lightning
 import torch
 
 from .. import transforms
@@ -122,9 +122,7 @@ class FrameClassificationModel(lightning.LightningModule):
         post_tfm : callable
             Post-processing transform applied to predictions.
         """
-        super().__init__(
-            network=network, loss=loss, optimizer=optimizer, metrics=metrics
-        )
+        super().__init__()
 
         self.labelmap = labelmap
         # replace any multiple character labels in mapping

--- a/src/vak/models/frame_classification_model.py
+++ b/src/vak/models/frame_classification_model.py
@@ -124,6 +124,11 @@ class FrameClassificationModel(lightning.LightningModule):
         """
         super().__init__()
 
+        self.network = network
+        self.loss = loss
+        self.optimizer = optimizer
+        self.metrics = metrics
+
         self.labelmap = labelmap
         # replace any multiple character labels in mapping
         # with single-character labels

--- a/src/vak/models/frame_classification_model.py
+++ b/src/vak/models/frame_classification_model.py
@@ -347,3 +347,34 @@ class FrameClassificationModel(lightning.LightningModule):
             raise ValueError(f"invalid shape for x: {x.shape}")
         y_pred = self.network(x)
         return {frames_path: y_pred}
+
+    def load_state_dict_from_path(self, ckpt_path):
+        """Loads a model from the path to a saved checkpoint.
+
+        Loads the checkpoint and then calls
+        ``self.load_state_dict`` with the ``state_dict``
+        in that chekcpoint.
+
+        This method allows loading a state dict into an instance.
+        It's necessary because `lightning.pytorch.LightningModule.load`` is a
+        ``classmethod``, so calling that method will trigger
+         ``LightningModule.__init__`` instead of running
+        ``vak.models.Model.__init__``.
+
+        Parameters
+        ----------
+        ckpt_path : str, pathlib.Path
+            Path to a checkpoint saved by a model in ``vak``.
+            This checkpoint has the same key-value pairs as
+            any other checkpoint saved by a
+            ``lightning.pytorch.LightningModule``.
+
+        Returns
+        -------
+        None
+
+        This method modifies the model state by loading the ``state_dict``;
+        it does not return anything.
+        """
+        ckpt = torch.load(ckpt_path)
+        self.load_state_dict(ckpt["state_dict"])

--- a/src/vak/models/get.py
+++ b/src/vak/models/get.py
@@ -50,7 +50,7 @@ def get(
     """
     # we do this dynamically so we always get all registered models
     try:
-        model_class = registry.MODEL_REGISTRY[name]
+        model_factory = registry.MODEL_REGISTRY[name]
     except KeyError as e:
         raise ValueError(
             f"Invalid model name: '{name}'.\n"
@@ -63,7 +63,7 @@ def get(
         # still need to special case model logic here
         net_init_params = list(
             inspect.signature(
-                model_class.definition.network.__init__
+                model_factory.definition.network.__init__
             ).parameters.keys()
         )
         if ("num_input_channels" in net_init_params) and (
@@ -82,13 +82,13 @@ def get(
                 f"unable to determine network init arguments for model. Currently all models "
                 f"in this family must have networks with parameters ``num_input_channels`` and ``num_freqbins``"
             )
-        model = model_class.from_config(
+        model = model_factory.from_config(
             config=config, labelmap=labelmap, post_tfm=post_tfm
         )
     elif model_family == "ParametricUMAPModel":
         encoder_init_params = list(
             inspect.signature(
-                model_class.definition.network["encoder"].__init__
+                model_factory.definition.network["encoder"].__init__
             ).parameters.keys()
         )
         if "input_shape" in encoder_init_params:
@@ -97,7 +97,7 @@ def get(
             else:
                 config["network"]["encoder"] = dict(input_shape=input_shape)
 
-        model = model_class.from_config(config=config)
+        model = model_factory.from_config(config=config)
     else:
         raise ValueError(
             f"Value for ``model_family`` not recognized: {model_family}"

--- a/src/vak/models/get.py
+++ b/src/vak/models/get.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import inspect
 from typing import Callable
 
+import lightning
+
 from . import registry
 
 
@@ -16,7 +18,7 @@ def get(
     num_classes: int | None = None,
     labelmap: dict | None = None,
     post_tfm: Callable | None = None,
-):
+) -> lightning.LightningModule:
     """Get a model instance, given its name and
     a configuration as a :class:`dict`.
 
@@ -44,9 +46,9 @@ def get(
 
     Returns
     -------
-    model : vak.models.Model
-        Instance of a sub-class of the base Model class,
-        e.g. a TweetyNet instance.
+    model : lightning.LightningModule
+        Instance of :class:`lightning.LightningModule`,
+        one of the model familes.
     """
     # we do this dynamically so we always get all registered models
     try:

--- a/src/vak/models/parametric_umap_model.py
+++ b/src/vak/models/parametric_umap_model.py
@@ -20,7 +20,7 @@ from .registry import model_family
 
 
 @model_family
-class ParametricUMAPModel(lightning.pytorch.LightningModule):
+class ParametricUMAPModel(lightning.LightningModule):
     """Parametric UMAP model, as described in [1]_.
 
     Notes
@@ -47,9 +47,7 @@ class ParametricUMAPModel(lightning.pytorch.LightningModule):
         optimizer: torch.optim.Optimizer | None = None,
         metrics: dict[str:Type] | None = None,
     ):
-        super().__init__(
-            network=network, loss=loss, optimizer=optimizer, metrics=metrics
-        )
+        super().__init__()
         self.encoder = network["encoder"]
         self.decoder = network.get("decoder", None)
 

--- a/src/vak/models/parametric_umap_model.py
+++ b/src/vak/models/parametric_umap_model.py
@@ -106,6 +106,37 @@ class ParametricUMAPModel(lightning.LightningModule):
         # note if there's no ``loss_reconstruction``, then ``loss`` == ``loss_umap``
         self.log("val_loss", loss, on_step=True)
 
+    def load_state_dict_from_path(self, ckpt_path):
+        """Loads a model from the path to a saved checkpoint.
+
+        Loads the checkpoint and then calls
+        ``self.load_state_dict`` with the ``state_dict``
+        in that chekcpoint.
+
+        This method allows loading a state dict into an instance.
+        It's necessary because `lightning.pytorch.LightningModule.load`` is a
+        ``classmethod``, so calling that method will trigger
+         ``LightningModule.__init__`` instead of running
+        ``vak.models.Model.__init__``.
+
+        Parameters
+        ----------
+        ckpt_path : str, pathlib.Path
+            Path to a checkpoint saved by a model in ``vak``.
+            This checkpoint has the same key-value pairs as
+            any other checkpoint saved by a
+            ``lightning.pytorch.LightningModule``.
+
+        Returns
+        -------
+        None
+
+        This method modifies the model state by loading the ``state_dict``;
+        it does not return anything.
+        """
+        ckpt = torch.load(ckpt_path)
+        self.load_state_dict(ckpt["state_dict"])
+
 
 class ParametricUMAPDatamodule(lightning.pytorch.LightningDataModule):
     def __init__(
@@ -189,34 +220,3 @@ class ParametricUMAP:
     @torch.no_grad()
     def inverse_transform(self, Z):
         return self.model.decoder(Z).detach().cpu().numpy()
-
-    def load_state_dict_from_path(self, ckpt_path):
-        """Loads a model from the path to a saved checkpoint.
-
-        Loads the checkpoint and then calls
-        ``self.load_state_dict`` with the ``state_dict``
-        in that chekcpoint.
-
-        This method allows loading a state dict into an instance.
-        It's necessary because `lightning.pytorch.LightningModule.load`` is a
-        ``classmethod``, so calling that method will trigger
-         ``LightningModule.__init__`` instead of running
-        ``vak.models.Model.__init__``.
-
-        Parameters
-        ----------
-        ckpt_path : str, pathlib.Path
-            Path to a checkpoint saved by a model in ``vak``.
-            This checkpoint has the same key-value pairs as
-            any other checkpoint saved by a
-            ``lightning.pytorch.LightningModule``.
-
-        Returns
-        -------
-        None
-
-        This method modifies the model state by loading the ``state_dict``;
-        it does not return anything.
-        """
-        ckpt = torch.load(ckpt_path)
-        self.load_state_dict(ckpt["state_dict"])

--- a/src/vak/models/parametric_umap_model.py
+++ b/src/vak/models/parametric_umap_model.py
@@ -15,13 +15,12 @@ import lightning
 import torch
 import torch.utils.data
 
-from . import base
 from .definition import ModelDefinition
 from .registry import model_family
 
 
 @model_family
-class ParametricUMAPModel(base.Model):
+class ParametricUMAPModel(lightning.pytorch.LightningModule):
     """Parametric UMAP model, as described in [1]_.
 
     Notes
@@ -103,27 +102,6 @@ class ParametricUMAPModel(base.Model):
             )
         # note if there's no ``loss_reconstruction``, then ``loss`` == ``loss_umap``
         self.log("val_loss", loss, on_step=True)
-
-    @classmethod
-    def from_config(cls, config: dict):
-        """Return an initialized model instance from a config ``dict``
-
-        Parameters
-        ----------
-        config : dict
-            Returned by calling :func:`vak.config.models.map_from_path`
-            or :func:`vak.config.models.map_from_config_dict`.
-
-        Returns
-        -------
-        cls : vak.models.base.Model
-            An instance of the model with its attributes
-            initialized using parameters from ``config``.
-        """
-        network, loss, optimizer, metrics = cls.attributes_from_config(config)
-        return cls(
-            network=network, optimizer=optimizer, loss=loss, metrics=metrics
-        )
 
 
 class ParametricUMAPDatamodule(lightning.pytorch.LightningDataModule):

--- a/src/vak/models/parametric_umap_model.py
+++ b/src/vak/models/parametric_umap_model.py
@@ -186,3 +186,34 @@ class ParametricUMAP:
     @torch.no_grad()
     def inverse_transform(self, Z):
         return self.model.decoder(Z).detach().cpu().numpy()
+
+    def load_state_dict_from_path(self, ckpt_path):
+        """Loads a model from the path to a saved checkpoint.
+
+        Loads the checkpoint and then calls
+        ``self.load_state_dict`` with the ``state_dict``
+        in that chekcpoint.
+
+        This method allows loading a state dict into an instance.
+        It's necessary because `lightning.pytorch.LightningModule.load`` is a
+        ``classmethod``, so calling that method will trigger
+         ``LightningModule.__init__`` instead of running
+        ``vak.models.Model.__init__``.
+
+        Parameters
+        ----------
+        ckpt_path : str, pathlib.Path
+            Path to a checkpoint saved by a model in ``vak``.
+            This checkpoint has the same key-value pairs as
+            any other checkpoint saved by a
+            ``lightning.pytorch.LightningModule``.
+
+        Returns
+        -------
+        None
+
+        This method modifies the model state by loading the ``state_dict``;
+        it does not return anything.
+        """
+        ckpt = torch.load(ckpt_path)
+        self.load_state_dict(ckpt["state_dict"])

--- a/src/vak/models/parametric_umap_model.py
+++ b/src/vak/models/parametric_umap_model.py
@@ -48,6 +48,11 @@ class ParametricUMAPModel(lightning.LightningModule):
         metrics: dict[str:Type] | None = None,
     ):
         super().__init__()
+        self.network = network
+        self.loss = loss
+        self.optimizer = optimizer
+        self.metrics = metrics
+
         self.encoder = network["encoder"]
         self.decoder = network.get("decoder", None)
 

--- a/src/vak/models/registry.py
+++ b/src/vak/models/registry.py
@@ -18,7 +18,7 @@ MODEL_FAMILY_REGISTRY = {}
 
 
 def model_family(family_class: Type) -> None:
-    """Decorator that adds a class to the registry of model families."""
+    """Decorator that adds a :class:`lightning.LightningModule` class to the registry of model families."""
     if not issubclass(family_class, lightning.LightningModule):
         raise TypeError(
             "The ``family_class`` provided to the `vak.models.model_family` decorator"
@@ -44,11 +44,15 @@ MODEL_REGISTRY = {}
 
 
 def register_model(model: ModelFactory) -> ModelFactory:
-    """Decorator that registers a model in the model registry.
+    """Function that registers a model in the model registry.
 
     This function is called by :func:`vak.models.decorator.model`,
-    that creates a model class from a model definition.
-    So you will not usually need to use this decorator directly,
+    that creates an instance of a :class:`vak.models.ModelFactory`,
+    given a :class:`vak.models.definition.ModelDefinition`
+    and a :class:`lightning.LightningModule` class that has been
+    registered as a model family with :func:`model_family`.
+
+    So you will not usually need to use this function directly,
     and should prefer to use :func:`vak.models.decorator.model` instead.
     """
     model_family_classes = list(MODEL_FAMILY_REGISTRY.values())
@@ -70,8 +74,8 @@ def register_model(model: ModelFactory) -> ModelFactory:
         )
 
     MODEL_REGISTRY[model_name] = model
-    # need to return class after we register it or we replace it with None
-    # when this function is used as a decorator
+    # need to return class after we register it,
+    # or we would replace it with None when this function is used as a decorator
     return model
 
 

--- a/src/vak/models/registry.py
+++ b/src/vak/models/registry.py
@@ -78,12 +78,10 @@ def register_model(model: Model) -> Model:
 def __getattr__(name: str) -> Any:
     """Module-level __getattr__ function that we use to dynamically determine models."""
     if name == "MODEL_FAMILY_FROM_NAME":
-        model_name_family_name_map = {}
-        for model_name, model_class in MODEL_REGISTRY.items():
-            model_parent_class = inspect.getmro(model_class)[1]
-            family_name = model_parent_class.__name__
-            model_name_family_name_map[model_name] = family_name
-        return model_name_family_name_map
+        return {
+            model_name: model.family.__name__
+            for model_name, model in MODEL_REGISTRY.items()
+        }
     elif name == "MODEL_NAMES":
         return list(MODEL_REGISTRY.keys())
     else:

--- a/src/vak/models/registry.py
+++ b/src/vak/models/registry.py
@@ -7,21 +7,24 @@ with a decorator, so that the model can be used at runtime.
 from __future__ import annotations
 
 import inspect
-from typing import Any, Type
+from typing import Any, Type, TYPE_CHECKING
 
 import lightning
+
+if TYPE_CHECKING:
+    from .base import Model
 
 MODEL_FAMILY_REGISTRY = {}
 
 
 def model_family(family_class: Type) -> None:
     """Decorator that adds a class to the registry of model families."""
-    if not issubclass(family_class, lightning.pytorch.LightningModule):
+    if not issubclass(family_class, lightning.LightningModule):
         raise TypeError(
             "The ``family_class`` provided to the `vak.models.model_family` decorator"
-            "must be a subclass of `lightning.pytorch.LightningModule`, "
+            "must be a subclass of `lightning.LightningModule`, "
             f"but the class specified is not: {family_class}. "
-            f"Subclasses of `lightning.pytorch.LightningModule` are: {lightning.pytorch.LightningModule.__subclasses__()}"
+            f"Subclasses of `lightning.LightningModule` are: {lightning.LightningModule.__subclasses__()}"
         )
 
     model_family_name = family_class.__name__
@@ -40,7 +43,7 @@ def model_family(family_class: Type) -> None:
 MODEL_REGISTRY = {}
 
 
-def register_model(model_class: Type) -> Type:
+def register_model(model: Model) -> Model:
     """Decorator that registers a model in the model registry.
 
     This function is called by :func:`vak.models.decorator.model`,
@@ -49,28 +52,27 @@ def register_model(model_class: Type) -> Type:
     and should prefer to use :func:`vak.models.decorator.model` instead.
     """
     model_family_classes = list(MODEL_FAMILY_REGISTRY.values())
-    model_parent_class = inspect.getmro(model_class)[1]
-    if model_parent_class not in model_family_classes:
+    model_family = model.family
+    if model_family not in model_family_classes:
         raise TypeError(
-            "The parent class of ``model_class`` passed to the ``model`` decorator "
-            f"is not recognized as a model family. Class was: {model_class} and "
-            f"parent is {model_parent_class}, as determined with "
-            f"``inspect.getmro(model_class)[1]``. "
-            f"Please specify a class that is a sub-class of a model family. "
+            "The family of `model` passed to the `register_model` decorator "
+            f"is not recognized as a model family. Class was '{model}' and "
+            f"its family is '{model_family}'. "
+            f"Please specify a valid model family. "
             f"Valid model family classes are: {model_family_classes}"
         )
 
-    model_name = model_class.__name__
+    model_name = model.__name__
     if model_name in MODEL_REGISTRY:
         raise ValueError(
             f"Attempted to register a model family with the name '{model_name}', "
             f"but this name is already in the registry.\n"
         )
 
-    MODEL_REGISTRY[model_name] = model_class
+    MODEL_REGISTRY[model_name] = model
     # need to return class after we register it or we replace it with None
     # when this function is used as a decorator
-    return model_class
+    return model
 
 
 def __getattr__(name: str) -> Any:

--- a/src/vak/models/registry.py
+++ b/src/vak/models/registry.py
@@ -12,7 +12,7 @@ from typing import Any, Type, TYPE_CHECKING
 import lightning
 
 if TYPE_CHECKING:
-    from .base import Model
+    from .factory import ModelFactory
 
 MODEL_FAMILY_REGISTRY = {}
 
@@ -43,7 +43,7 @@ def model_family(family_class: Type) -> None:
 MODEL_REGISTRY = {}
 
 
-def register_model(model: Model) -> Model:
+def register_model(model: ModelFactory) -> ModelFactory:
     """Decorator that registers a model in the model registry.
 
     This function is called by :func:`vak.models.decorator.model`,

--- a/src/vak/models/registry.py
+++ b/src/vak/models/registry.py
@@ -9,19 +9,19 @@ from __future__ import annotations
 import inspect
 from typing import Any, Type
 
-from .base import Model
+import lightning
 
 MODEL_FAMILY_REGISTRY = {}
 
 
 def model_family(family_class: Type) -> None:
     """Decorator that adds a class to the registry of model families."""
-    if family_class not in Model.__subclasses__():
+    if not issubclass(family_class, lightning.pytorch.LightningModule):
         raise TypeError(
             "The ``family_class`` provided to the `vak.models.model_family` decorator"
-            "must be a subclass of `vak.models.base.Model`, "
+            "must be a subclass of `lightning.pytorch.LightningModule`, "
             f"but the class specified is not: {family_class}. "
-            f"Subclasses of `vak.models.base.Model` are: {Model.__subclasses__()}"
+            f"Subclasses of `lightning.pytorch.LightningModule` are: {lightning.pytorch.LightningModule.__subclasses__()}"
         )
 
     model_family_name = family_class.__name__

--- a/tests/data_for_tests/configs/ConvEncoderUMAP_eval_audio_cbin_annot_notmat.toml
+++ b/tests/data_for_tests/configs/ConvEncoderUMAP_eval_audio_cbin_annot_notmat.toml
@@ -20,7 +20,7 @@ num_workers = 16
 
 output_dir = "./tests/data_for_tests/generated/results/eval/audio_cbin_annot_notmat/ConvEncoderUMAP"
 
-[vak.eval.model.ConvEncoderUMAP.network]
+[vak.eval.model.ConvEncoderUMAP.network.encoder]
 conv1_filters = 8
 conv2_filters = 16
 conv_kernel_size = 3

--- a/tests/data_for_tests/configs/ConvEncoderUMAP_train_audio_cbin_annot_notmat.toml
+++ b/tests/data_for_tests/configs/ConvEncoderUMAP_train_audio_cbin_annot_notmat.toml
@@ -24,7 +24,7 @@ num_workers = 16
 
 root_results_dir = "./tests/data_for_tests/generated/results/train/audio_cbin_annot_notmat/ConvEncoderUMAP"
 
-[vak.train.model.ConvEncoderUMAP.network]
+[vak.train.model.ConvEncoderUMAP.network.encoder]
 conv1_filters = 8
 conv2_filters = 16
 conv_kernel_size = 3

--- a/tests/test_config/test_model.py
+++ b/tests/test_config/test_model.py
@@ -64,7 +64,17 @@ class TestModelConfig:
                 },
                 {
                     "ConvEncoderUMAP": {
-                        "optimizer": 1e-3
+                        "optimizer": {'lr': 1e-3},
+                    }
+                },
+                {
+                    "ConvEncoderUMAP": {
+                        "network": {
+                            "encoder": {
+                                "conv1_filters": 8,
+                            }
+                        },
+                        "optimizer": {'lr': 1e-3},
                     }
                 }
             ]
@@ -127,7 +137,17 @@ class TestModelConfig:
                 },
                 {
                     "ConvEncoderUMAP": {
-                        "optimizer": 1e-3
+                        "optimizer": {'lr': 1e-3},
+                    }
+                },
+                {
+                    "ConvEncoderUMAP": {
+                        "network": {
+                            "encoder": {
+                                "conv1_filters": 8,
+                            }
+                        },
+                        "optimizer": {'lr': 1e-3},
                     }
                 }
             ]

--- a/tests/test_models/conftest.py
+++ b/tests/test_models/conftest.py
@@ -1,3 +1,4 @@
+import lightning
 import torch
 
 import vak.models.registry
@@ -76,7 +77,7 @@ class MockAcc:
 
 
 # ---- mock model families ---------------------------------------------------------------------------------------------
-class UnregisteredMockModelFamily(vak.models.Model):
+class UnregisteredMockModelFamily(lightning.LightningModule):
     """A model family defined only for tests.
     Used to test :func:`vak.models.registry.model_family`.
     """
@@ -90,17 +91,6 @@ class UnregisteredMockModelFamily(vak.models.Model):
 
     def validation_step(self, *args, **kwargs):
         pass
-
-    @classmethod
-    def from_config(cls, config: dict):
-        """Return an initialized model instance from a config ``dict``."""
-        network, loss, optimizer, metrics = cls.attributes_from_config(config)
-        return cls(
-            network=network,
-            optimizer=optimizer,
-            loss=loss,
-            metrics=metrics,
-        )
 
 
 # Make a "copy" of UnregisteredModelFamily that we *do* register

--- a/tests/test_models/conftest.py
+++ b/tests/test_models/conftest.py
@@ -82,9 +82,11 @@ class UnregisteredMockModelFamily(lightning.LightningModule):
     Used to test :func:`vak.models.registry.model_family`.
     """
     def __init__(self, network, optimizer, loss, metrics):
-        super().__init__(
-            network=network, loss=loss, optimizer=optimizer, metrics=metrics
-        )
+        super().__init__()
+        self.network=network
+        self.loss=loss
+        self.optimizer=optimizer
+        self.metrics=metrics
 
     def training_step(self, *args, **kwargs):
         pass
@@ -98,9 +100,23 @@ class UnregisteredMockModelFamily(lightning.LightningModule):
 # that require a registered ModelFamily.
 # Used when testing :func:`vak.models.decorator.model` -- we need a model in the registry to test
 # and we don't want to have to deal with the idiosyncrasies of actual model families
-MockModelFamily = type('MockModelFamily',
-                       UnregisteredMockModelFamily.__bases__,
-                       dict(UnregisteredMockModelFamily.__dict__))
+class MockModelFamily(lightning.LightningModule):
+    """A model family defined only for tests.
+    Used to test :func:`vak.models.registry.model_family`.
+    """
+    def __init__(self, network, optimizer, loss, metrics):
+        super().__init__()
+        self.network=network
+        self.loss=loss
+        self.optimizer=optimizer
+        self.metrics=metrics
+
+    def training_step(self, *args, **kwargs):
+        pass
+
+    def validation_step(self, *args, **kwargs):
+        pass
+
 vak.models.registry.model_family(MockModelFamily)
 
 

--- a/tests/test_models/test_convencoder_umap.py
+++ b/tests/test_models/test_convencoder_umap.py
@@ -11,7 +11,7 @@ class TestConvEncoderUMAP:
             (1, 64, 64),
         ]
     )
-    def test_init(self, input_shape):
+    def test_from_instances(self, input_shape):
         network = {
             'encoder': vak.models.ConvEncoderUMAP.definition.network['encoder'](input_shape=input_shape)
         }

--- a/tests/test_models/test_convencoder_umap.py
+++ b/tests/test_models/test_convencoder_umap.py
@@ -15,8 +15,8 @@ class TestConvEncoderUMAP:
         network = {
             'encoder': vak.models.ConvEncoderUMAP.definition.network['encoder'](input_shape=input_shape)
         }
-        model = vak.models.ConvEncoderUMAP(network=network)
-        assert isinstance(model, vak.models.ConvEncoderUMAP)
+        model = vak.models.ConvEncoderUMAP.from_instances(network=network)
+        assert isinstance(model, vak.models.ParametricUMAPModel)
         for attr in ('network', 'loss', 'optimizer'):
             assert hasattr(model, attr)
             attr_from_definition = getattr(vak.models.convencoder_umap.ConvEncoderUMAP.definition, attr)

--- a/tests/test_models/test_convencoder_umap.py
+++ b/tests/test_models/test_convencoder_umap.py
@@ -1,4 +1,5 @@
 import pytest
+import torch
 
 import vak
 
@@ -22,7 +23,7 @@ class TestConvEncoderUMAP:
             attr_from_definition = getattr(vak.models.convencoder_umap.ConvEncoderUMAP.definition, attr)
             if isinstance(attr_from_definition, dict):
                 attr_from_model = getattr(model, attr)
-                assert isinstance(attr_from_model, dict)
+                assert isinstance(attr_from_model, (dict, torch.nn.ModuleDict))
                 assert attr_from_model.keys() == attr_from_definition.keys()
                 for net_name, net_instance in attr_from_model.items():
                     assert isinstance(net_instance, attr_from_definition[net_name])

--- a/tests/test_models/test_decorator.py
+++ b/tests/test_models/test_decorator.py
@@ -35,11 +35,13 @@ TweetyNet.__name__ = 'TweetyNet'
 )
 def test_model(definition, family, expected_name):
     """Test that :func:`vak.models.decorator.model` decorator
-    returns a subclass of the specified model family,
+    returns a new instance of ModelFactory,
     and has the expected name"""
     model_class = vak.models.decorator.model(family)(definition)
-    assert issubclass(model_class, family)
+
+    assert isinstance(model_class, vak.models.factory.ModelFactory)
     assert model_class.__name__ == expected_name
+
     # need to delete model from registry so other tests don't fail
     del vak.models.registry.MODEL_REGISTRY[model_class.__name__]
 
@@ -61,4 +63,4 @@ def test_model(definition, family, expected_name):
 )
 def test_model_raises(definition):
     with pytest.raises(vak.models.decorator.ModelDefinitionValidationError):
-        vak.models.decorator.model(vak.models.base.Model)(definition)
+        vak.models.decorator.model(MockModelFamily)(definition)

--- a/tests/test_models/test_ed_tcn.py
+++ b/tests/test_models/test_ed_tcn.py
@@ -15,8 +15,8 @@ class TestED_TCN:
         num_input_channels = input_shape[-3]
         num_freqbins = input_shape[-2]
         network = vak.models.ED_TCN.definition.network(len(labelmap), num_input_channels, num_freqbins)
-        model = vak.models.ED_TCN(labelmap=labelmap, network=network)
-        assert isinstance(model, vak.models.ED_TCN)
+        model = vak.models.ED_TCN.from_instances(network=network, labelmap=labelmap)
+        assert isinstance(model, vak.models.FrameClassificationModel)
         for attr in ('network', 'loss', 'optimizer'):
             assert hasattr(model, attr)
             assert isinstance(getattr(model, attr),

--- a/tests/test_models/test_factory.py
+++ b/tests/test_models/test_factory.py
@@ -417,9 +417,7 @@ class TestModelFactory:
         )
 
         config = cfg.train.model.asdict()
-        config["network"].update(
-            encoder=dict(input_shape=input_shape)
-        )
+        config["network"]["encoder"]["input_shape"] = input_shape
 
         model = model_factory.from_config(config=config)
         assert isinstance(model, vak.models.ParametricUMAPModel)
@@ -432,8 +430,9 @@ class TestModelFactory:
             elif isinstance(definition.network, dict):
                 for net_name, net_kwargs in config['network'].items():
                     for network_kwarg, network_kwargval in net_kwargs.items():
-                        assert hasattr(model.network[net_name], network_kwarg)
-                        assert getattr(model.network[net_name], network_kwarg) == network_kwargval
+                        network = getattr(model, net_name)
+                        if hasattr(network, network_kwarg):
+                            assert getattr(network, network_kwarg) == network_kwargval
 
         if 'loss' in config:
             for loss_kwarg, loss_kwargval in config['loss'].items():

--- a/tests/test_models/test_factory.py
+++ b/tests/test_models/test_factory.py
@@ -363,7 +363,6 @@ class TestModelFactory:
             input_shape,
             definition,
     ):
-        # monkeypatch a definition so we can test __init__
         network = {'encoder': vak.nets.ConvEncoder(input_shape)}
 
         model_factory = vak.models.ModelFactory(
@@ -381,7 +380,7 @@ class TestModelFactory:
             if inspect.isclass(definition_attr):
                 assert isinstance(model_attr, definition_attr)
             elif isinstance(definition_attr, dict):
-                assert isinstance(model_attr, dict)
+                assert isinstance(model_attr, (dict, torch.nn.ModuleDict))
                 for definition_key, definition_val in definition_attr.items():
                     assert definition_key in model_attr
                     model_val = model_attr[definition_key]
@@ -430,7 +429,7 @@ class TestModelFactory:
             elif isinstance(definition.network, dict):
                 for net_name, net_kwargs in config['network'].items():
                     for network_kwarg, network_kwargval in net_kwargs.items():
-                        network = getattr(model, net_name)
+                        network = model.network[net_name]
                         if hasattr(network, network_kwarg):
                             assert getattr(network, network_kwarg) == network_kwargval
 

--- a/tests/test_models/test_factory.py
+++ b/tests/test_models/test_factory.py
@@ -81,12 +81,12 @@ class TestModel:
     def test_init_no_definition_raises(self):
         """Test that initializing a Model instance without a definition or family raises a ValueError."""
         with pytest.raises(TypeError):
-            vak.models.base.Model()
+            vak.models.factory.ModelFactory()
 
     def test_init_invalid_definition_raises(self):
         """Test that initializing a Model instance with an invalid definition raises a ValueError."""
         with pytest.raises(vak.models.decorator.ModelDefinitionValidationError):
-            vak.models.base.Model(
+            vak.models.factory.ModelFactory(
                 definition=InvalidMetricsDictKeyModelDefinition,
                 family=MockModelFamily,
             )
@@ -96,7 +96,7 @@ class TestModel:
         TEST_INIT_ARGVALS,
     )
     def test_validate_instances_or_get_default(self, definition, kwargs):
-        model = vak.models.base.Model(
+        model = vak.models.factory.ModelFactory(
             definition,
             MockModelFamily,
         )
@@ -151,7 +151,7 @@ class TestModel:
         so here we test that this is happening inside ``validate_instances_or_get_default``.
         Next method tests ``validate_init`` directly.
         """
-        model = vak.models.base.Model(
+        model = vak.models.factory.ModelFactory(
             definition,
             MockModelFamily,
         )
@@ -165,7 +165,7 @@ class TestModel:
     def test_validate_init_raises(self, definition, kwargs, expected_exception):
         """Test that ``validate_init`` raises errors as expected"""
         # monkeypatch a definition so we can test __init__
-        model = vak.models.base.Model(
+        model = vak.models.factory.ModelFactory(
             definition=definition,
             family=MockModelFamily
         )
@@ -199,7 +199,7 @@ class TestModel:
                          definition,
                          config,
                          ):
-        model = vak.models.base.Model(
+        model = vak.models.factory.ModelFactory(
             definition=definition,
             family=MockModelFamily
         )

--- a/tests/test_models/test_frame_classification_model.py
+++ b/tests/test_models/test_frame_classification_model.py
@@ -22,7 +22,6 @@ class TestFrameClassificationModel:
     def test_load_state_dict_from_path(self,
                                        model_name,
                                        specific_config_toml_path,
-                                       monkeypatch,
                                        device
                                        ):
         """Smoke test that makes sure ``load_state_dict_from_path`` runs without failure.

--- a/tests/test_models/test_frame_classification_model.py
+++ b/tests/test_models/test_frame_classification_model.py
@@ -1,138 +1,92 @@
-import inspect
-import itertools
+import copy
+from .test_definition import TweetyNetDefinition
+
 
 import pytest
 import torch
 
 import vak.models
 
-from .test_definition import (
-    TweetyNetDefinition,
-)
-from .test_tweetynet import LABELMAPS, INPUT_SHAPES
-
-
-# pytest.mark.parametrize vals for test_init_with_definition
-MODEL_DEFS = (
-    TweetyNetDefinition,
-)
-
-TEST_INIT_ARGVALS = itertools.product(LABELMAPS, INPUT_SHAPES, MODEL_DEFS)
-
-
 class TestFrameClassificationModel:
 
-    @pytest.mark.parametrize(
-        'labelmap, input_shape, definition',
-        TEST_INIT_ARGVALS
-    )
-    def test_init(self,
-                  labelmap,
-                  input_shape,
-                  definition,
-                  monkeypatch):
-        """Test FrameClassificationModel.__init__ works as expected"""
-        # monkeypatch a definition so we can test __init__
-        definition = vak.models.definition.validate(definition)
-        monkeypatch.setattr(
-            vak.models.FrameClassificationModel,
-            'definition',
-            definition,
-            raising=False
-        )
-        num_input_channels, num_freqbins = input_shape[0], input_shape[1]
-        # network has required args that need to be determined dynamically
-        network = definition.network(len(labelmap), num_input_channels, num_freqbins)
-        model = vak.models.FrameClassificationModel(labelmap=labelmap, network=network)
-
-        # now test that attributes are what we expect
-        assert isinstance(model, vak.models.FrameClassificationModel)
-        for attr in ('network', 'loss', 'optimizer', 'metrics'):
-            assert hasattr(model, attr)
-            model_attr = getattr(model, attr)
-            definition_attr = getattr(definition, attr)
-            if inspect.isclass(definition_attr):
-                assert isinstance(model_attr, definition_attr)
-            elif isinstance(definition_attr, dict):
-                assert isinstance(model_attr, dict)
-                for definition_key, definition_val in definition_attr.items():
-                    assert definition_key in model_attr
-                    model_val = model_attr[definition_key]
-                    if inspect.isclass(definition_val):
-                        assert isinstance(model_val, definition_val)
-                    else:
-                        assert callable(definition_val)
-                        assert model_val is definition_val
-            else:
-                # must be a function
-                assert callable(model_attr)
-                assert model_attr is definition_attr
-
-    MOCK_INPUT_SHAPE = torch.Size([1, 128, 44])
+    MODEL_DEFINITION_MAP = {
+        'TweetyNet': TweetyNetDefinition,
+    }
 
     @pytest.mark.parametrize(
-        'definition',
+        'model_name',
         [
-            TweetyNetDefinition,
+            'TweetyNet',
         ]
     )
-    def test_from_config(self,
-                         definition,
-                         # our fixtures
-                         specific_config_toml_path,
-                         # pytest fixtures
-                         monkeypatch,
-                         ):
-        definition = vak.models.definition.validate(definition)
-        model_name = definition.__name__.replace('Definition', '')
-        toml_path = specific_config_toml_path('train', model_name, audio_format='cbin', annot_format='notmat')
-        cfg = vak.config.Config.from_toml_path(toml_path)
+    def test_load_state_dict_from_path(self,
+                                       model_name,
+                                       specific_config_toml_path,
+                                       monkeypatch,
+                                       device
+                                       ):
+        """Smoke test that makes sure ``load_state_dict_from_path`` runs without failure.
+
+        We use actual model definitions here so we can test with real checkpoints.
+        """
+        definition = self.MODEL_DEFINITION_MAP[model_name]
+        train_toml_path = specific_config_toml_path('train', model_name, audio_format='cbin', annot_format='notmat')
+        train_cfg = vak.config.Config.from_toml_path(train_toml_path)
 
         # stuff we need just to be able to instantiate network
-        labelmap = vak.common.labels.to_map(cfg.prep.labelset, map_unlabeled=True)
-
-        monkeypatch.setattr(
-            vak.models.FrameClassificationModel, 'definition', definition, raising=False
+        labelmap = vak.common.labels.to_map(train_cfg.prep.labelset, map_unlabeled=True)
+        item_transform = vak.transforms.defaults.get_default_transform(
+            model_name,
+            "train",
+            transform_kwargs={},
         )
-
-        config = cfg.train.model.asdict()
-        num_input_channels, num_freqbins = self.MOCK_INPUT_SHAPE[0], self.MOCK_INPUT_SHAPE[1]
-
-        config["network"].update(
-            num_classes=len(labelmap),
-            num_input_channels=num_input_channels,
-            num_freqbins=num_freqbins
+        train_dataset = vak.datasets.frame_classification.WindowDataset.from_dataset_path(
+            dataset_path=train_cfg.train.dataset.path,
+            split="train",
+            window_size=train_cfg.train.dataset.params['window_size'],
+            item_transform=item_transform,
         )
+        input_shape = train_dataset.shape
+        num_input_channels = input_shape[-3]
+        num_freqbins = input_shape[-2]
 
-        model = vak.models.FrameClassificationModel.from_config(config=config, labelmap=labelmap)
-        assert isinstance(model, vak.models.FrameClassificationModel)
+        # network is the one thing that has required args
+        # and we also need to use its config from the toml file
+        cfg = vak.config.Config.from_toml_path(train_toml_path)
+        model_config = cfg.train.model.asdict()
+        network = definition.network(num_classes=len(labelmap),
+                                     num_input_channels=num_input_channels,
+                                     num_freqbins=num_freqbins,
+                                     **model_config['network'])
+        model_factory = vak.models.factory.ModelFactory(
+            definition,
+            vak.models.FrameClassificationModel,
+        )
+        model = model_factory.from_instances(network=network, labelmap=labelmap)
+        model.to(device)
 
-        # below, we can only test the config kwargs that actually end up as attributes
-        # so we use `if hasattr` before checking
-        if 'network' in config:
-            if inspect.isclass(definition.network):
-                for network_kwarg, network_kwargval in config['network'].items():
-                    if hasattr(model.network, network_kwarg):
-                        assert getattr(model.network, network_kwarg) == network_kwargval
-            elif isinstance(definition.network, dict):
-                for net_name, net_kwargs in config['network'].items():
-                    for network_kwarg, network_kwargval in net_kwargs.items():
-                        if hasattr(model.network[net_name], network_kwarg):
-                            assert getattr(model.network[net_name], network_kwarg) == network_kwargval
+        eval_toml_path = specific_config_toml_path('eval', model_name, audio_format='cbin', annot_format='notmat')
+        eval_cfg = vak.config.Config.from_toml_path(eval_toml_path)
+        checkpoint_path = eval_cfg.eval.checkpoint_path
 
-        if 'loss' in config:
-            for loss_kwarg, loss_kwargval in config['loss'].items():
-                if hasattr(model.loss, loss_kwarg):
-                    assert getattr(model.loss, loss_kwarg) == loss_kwargval
+        # ---- actually test method
+        sd_before = copy.deepcopy(model.state_dict())
+        sd_before = {
+            k: v.to(device) for k, v in sd_before.items()
+        }
+        ckpt = torch.load(checkpoint_path)
+        sd_to_be_loaded = ckpt['state_dict']
+        sd_to_be_loaded = {
+            k: v.to(device) for k, v in sd_to_be_loaded.items()
+        }
 
-        if 'optimizer' in config:
-            for optimizer_kwarg, optimizer_kwargval in config['optimizer'].items():
-                if optimizer_kwarg in model.optimizer.param_groups[0]:
-                    assert model.optimizer.param_groups[0][optimizer_kwarg] == optimizer_kwargval
+        model.load_state_dict_from_path(checkpoint_path)
 
-        if 'metrics' in config:
-            for metric_name, metric_kwargs in config['metrics'].items():
-                assert metric_name in model.metrics
-                for metric_kwarg, metric_kwargval in metric_kwargs.items():
-                    if hasattr(model.metrics[metric_name], metric_kwarg):
-                        assert getattr(model.metrics[metric_name], metric_kwarg) == metric_kwargval
+        assert not all([
+            torch.all(torch.eq(val, before_val))
+            for val, before_val in zip(model.state_dict().values(), sd_before.values())]
+        )
+        assert all([
+            torch.all(torch.eq(val, before_val))
+            for val, before_val in zip(model.state_dict().values(), sd_to_be_loaded.values())]
+        )

--- a/tests/test_models/test_parametric_umap_model.py
+++ b/tests/test_models/test_parametric_umap_model.py
@@ -53,7 +53,7 @@ class TestParametricUMAPModel:
         network = {
             'encoder': definition.network['encoder'](
                 input_shape=train_dataset.shape,
-                **model_config['network']
+                **model_config['network']['encoder']
                 )
         }
         model_factory = vak.models.factory.ModelFactory(

--- a/tests/test_models/test_tweetynet.py
+++ b/tests/test_models/test_tweetynet.py
@@ -1,7 +1,6 @@
 import itertools
 
 import pytest
-import lightning
 
 import vak
 
@@ -31,13 +30,6 @@ TEST_INIT_ARGVALS = itertools.product(LABELMAPS, INPUT_SHAPES)
 
 
 class TestTweetyNet:
-    def test_model_is_decorated(self):
-        assert issubclass(vak.models.TweetyNet,
-                          vak.models.FrameClassificationModel)
-        assert issubclass(vak.models.TweetyNet,
-                          vak.models.base.Model)
-        assert issubclass(vak.models.TweetyNet,
-                          lightning.pytorch.LightningModule)
 
     @pytest.mark.parametrize(
         'labelmap, input_shape',
@@ -48,8 +40,8 @@ class TestTweetyNet:
         num_input_channels = input_shape[-3]
         num_freqbins = input_shape[-2]
         network = vak.models.TweetyNet.definition.network(len(labelmap), num_input_channels, num_freqbins)
-        model = vak.models.TweetyNet(labelmap=labelmap, network=network)
-        assert isinstance(model, vak.models.TweetyNet)
+        model = vak.models.TweetyNet.from_instances(network=network, labelmap=labelmap)
+        assert isinstance(model, vak.models.FrameClassificationModel)
         for attr in ('network', 'loss', 'optimizer'):
             assert hasattr(model, attr)
             assert isinstance(getattr(model, attr),


### PR DESCRIPTION
This PR refactors the model abstraction, basically as described here: https://github.com/vocalpy/vak/issues/737#issuecomment-2094911335

We replace `vak.models.base.Model`, that sub-classed `lightning.LightningModule`, with `vak.models.factory.ModelFactory`, that no longer sub-classes `LightningModule`. Instead, its `__init__` takes a model definition and a model family, the latter of which is a `lightning.LightningModule`, and its `from_config` and `from_instances` methods return new instances of the `family`, with instances of the `network`, `loss`, `optimizer`, and `metrics` attributes of the definition.

This is really just a shim, in the form of several layers of indirection, to fix the broken logging for now. I'm not sure it makes it much easier to add a model (see #751). 

But it does appear to fix the logging issue--logs look as expected when I inspect them now.