### PR TITLE
DOC: Update autoannoate tutorial, fix #768

### DIFF
--- a/doc/get_started/autoannotate.md
+++ b/doc/get_started/autoannotate.md
@@ -257,7 +257,7 @@ where to find those files when we need them below.
 root_results_dir = "/home/users/You/Data/vak_tutorial_data/vak/train/results"
 ```
 
-Here it's fine to use the same directory you created before, or make a new one if you prepare to keep the
+Here it's fine to use the same directory you created before, or make a new one if you prefer to keep the
 training data and the files from training the neural network separate.
 `vak` will make a new directory inside of `root_results_dir` to save the files related to training
 every time that you run the `train` command.
@@ -357,10 +357,18 @@ spect_scaler = "/home/users/You/Data/vak_tutorial_data/vak_output/results_{times
 ```
 
 The last path you need is actually in the TOML file that we used
-to train the neural network: `dataset_path`.
-You should copy that `dataset_path` option exactly as it is
-and then paste it at the bottom of the `[EVAL]` table
+to train the neural network: the dataset `path`.
+You should copy that `path` option exactly as it is
+and then paste it at the bottom of the `[vak.eval.dataset]` table
 in the configuration file for evaluation.
+
+```toml
+[vak.eval.dataset]
+# copy the dataset path from the train config file here;
+# we will use the "test" split from that dataset, that we already prepared
+path = ""/home/users/You/Data/vak_tutorial_data/vak/prep/train/dataset_prepared_20240811"
+```
+
 We do this instead of preparing another dataset,
 because we already created a test split when we ran
 `vak prep` with the training configuration.

--- a/doc/get_started/autoannotate.md
+++ b/doc/get_started/autoannotate.md
@@ -366,7 +366,7 @@ in the configuration file for evaluation.
 [vak.eval.dataset]
 # copy the dataset path from the train config file here;
 # we will use the "test" split from that dataset, that we already prepared
-path = ""/home/users/You/Data/vak_tutorial_data/vak/prep/train/dataset_prepared_20240811"
+path = "/home/users/You/Data/vak_tutorial_data/vak/prep/train/dataset_prepared_20240811"
 ```
 
 We do this instead of preparing another dataset,

--- a/doc/toml/gy6or6_eval.toml
+++ b/doc/toml/gy6or6_eval.toml
@@ -66,12 +66,17 @@ min_segment_dur = 0.02
 
 # dataset.params = parameters used for datasets
 # for a frame classification model, we use dataset classes with a specific `window_size`
-[vak.eval.dataset.params]
-window_size = 176
+[vak.eval.dataset]
+path = "/copy/path/from/train/config/here"
+params = { window_size = 176 }
 
-# Note we do not specify any options for the model, and just use the defaults
-# We need to put this table here though so we know which model we are using
-[vak.eval.model.TweetyNet]
+# We put this table though vak knows which model we are using
+[vak.eval.model.TweetyNet.network]
+# hidden_size: the number of elements in the hidden state in the recurrent layer of the network
+# we trained with hidden size = 256 so we need to evaluate with the same hidden size;
+# otherwise we'll get an error about "shapes do not match" when torch tries to load the checkpoint
+hidden_size = 256
+
 
 # this sub-table configures the `lightning.pytorch.Trainer`
 [vak.eval.trainer]

--- a/doc/toml/gy6or6_predict.toml
+++ b/doc/toml/gy6or6_predict.toml
@@ -61,12 +61,16 @@ min_segment_dur = 0.01
 
 # dataset.params = parameters used for datasets
 # for a frame classification model, we use dataset classes with a specific `window_size`
-[vak.predict.dataset.params]
-window_size = 176
+[vak.predict.dataset]
+path = "/copy/path/from/train/config/here"
+params = { window_size = 176 }
 
-# Note we do not specify any options for the network, and just use the defaults
-# We need to put this table here though, to indicate which model we are using.
-[vak.predict.model.TweetyNet]
+# We put this table though vak knows which model we are using
+[vak.predict.model.TweetyNet.network]
+# hidden_size: the number of elements in the hidden state in the recurrent layer of the network
+# we trained with hidden size = 256 so we need to evaluate with the same hidden size;
+# otherwise we'll get an error about "shapes do not match" when torch tries to load the checkpoint
+hidden_size = 256
 
 # this sub-table configures the `lightning.pytorch.Trainer`
 [vak.predict.trainer]


### PR DESCRIPTION
Fixes documentation and accompanying config files so it is clearer where the dataset `path` option should go